### PR TITLE
Restore _station_z and uncalibrated_tools, dropped (not renamed) by an earlier refactor

### DIFF
--- a/payload/klipper/extras/ff_toolchange.py
+++ b/payload/klipper/extras/ff_toolchange.py
@@ -1184,6 +1184,16 @@ class FFToolchange:
             return
         self.printer.lookup_object('gcode_move').reset_last_position()
 
+    def uncalibrated_tools(self):
+        return [tool.index for tool in self.tools if not tool.calibrated()]
+
+    def _station_z(self):
+        """station_z from [ff_tool_offset] (TOOL_LOCATE_SENSOR), or None."""
+        offsets = self.printer.lookup_object('ff_tool_offset', None)
+        if offsets is None or offsets.station is None:
+            return None
+        return offsets.station[2]
+
     def _set_tool_frame(self, tool):
         """Make `tool` (or None for a bare carriage) the per-tool frame.
 


### PR DESCRIPTION
## Summary
- c9eaadf's refactor deleted `_station_z()` and `uncalibrated_tools()` from `ff_toolchange.py` in the same diff hunk as two genuinely dead methods it meant to remove -- these two were not dead: five call sites for the first and two for the second are still live.
- Klipper's own test suite didn't catch it: `test_tool_transform.py`'s fixtures monkeypatch `tc._station_z = lambda: None` before use, which works whether or not the class defines the method. The gap only surfaced as `FFToolchange object has no attribute '_station_z'` out of a real `load_config`, on a real printer.
- Both methods restored unchanged from before c9eaadf. Checked for the same shape elsewhere in the file -- no other `self.method()` call lacks a matching `def`.

Cherry-picked from `worktree-s6-vs-runit` (fc429a7).

## Test plan
- [x] `python3 -m pytest test/integration -q -k "toolchange or tool_transform"` -> 24 passed
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDGToVxTP482SDsTRUhWm7