### PR TITLE
Pin HelixScreen creator5.3

### DIFF
--- a/versions.env
+++ b/versions.env
@@ -41,9 +41,9 @@ MIPS_TOOLCHAIN_VERSION="1.0.0"
 MIPS_TOOLCHAIN_FILE="mips-gcc720-glibc229.tar.gz"
 MIPS_TOOLCHAIN_SHA256="c0415a857c6b384820ec61b8a30c89e528585f3ef07d580fc856e80313c9d2e8"
 
-HELIX_VERSION="v0.99.115-creator5.2"
+HELIX_VERSION="v0.99.115-creator5.3"
 HELIX_FILE="helixscreen-creator5-v0.99.115.tar.gz"
-HELIX_SHA256="dd66dd9b1bdd73f77d7c7f7d76003b14121c5cf102a755083ef7506fbdb22d7d"
+HELIX_SHA256="d3956458dbd1f1ab621993306006320803d7660d62e1371e6ce069e5e91b4eb5"
 
 # Moonraker: a RELEASE TAG, not a commit. The old pin was the last commit
 # before 80c7620 moved the database from lmdb to sqlite, because 3.8.2 has no


### PR DESCRIPTION
## Summary
- Bumps `HELIX_VERSION` to `v0.99.115-creator5.3` (build 4) — https://github.com/Klipper4FlashForge/helixscreen/releases/tag/v0.99.115-creator5.3
- Contains one upstream commit since -creator5.2: `feat(ams): separate the tool and material axes on tool changers`
- Upstream `VERSION.txt` is unchanged (0.99.115), so `HELIX_FILE` is the same, only `HELIX_SHA256` changes
- SHA256 verified against the downloaded release asset before committing

## Test plan
- [x] Downloaded `helixscreen-creator5-v0.99.115.tar.gz` from the new release and confirmed its sha256 matches the pinned `HELIX_SHA256`