### PR TITLE
Service definitions reach the printer: postinst compile, config relinking, and a clock that is actually set

### DIFF
--- a/pkgs/3rdparty/s6-rc/build.sh
+++ b/pkgs/3rdparty/s6-rc/build.sh
@@ -10,11 +10,17 @@
 # refuses to run over a live directory that already exists. Whether /run is
 # tmpfs on this printer is the one thing here not checked on hardware.
 #
-# WHAT SHIPS is the runtime, not the whole toolbox. s6-rc-compile is a BUILD
-# tool -- it runs where the database is compiled, not on the printer.
-# s6-rc-update swaps a live database without a reboot, which on this machine
-# an update is anyway. What is left is the three programs that bring services
-# up and down and the two the generated databases exec by absolute path.
+# WHAT SHIPS is the runtime plus the two tools a printer needs to change its
+# own database, which it now does: anvil-core's postinst compiles a new one on
+# every upgrade of the service definitions.
+#
+# s6-rc-update is what makes that safe. s6-rc-init records the live state as
+# one byte per service in the database it booted, and /run/s6-rc/compiled is a
+# symlink to compiled/current -- so moving `current` under a running system
+# leaves a state file whose size no longer matches, and every `s6-rc` command
+# fails with "unable to read valid state" until the next boot. s6-rc-update
+# reconciles the live state with the new database instead, leaving unchanged
+# services alone. Measured on a printer, 2026-08-31.
 set -euo pipefail
 . ./bin/common.sh
 . pkgs/lib.sh
@@ -43,7 +49,7 @@ PKG_STRIP_ARGS=""
 # s6-rc-compile ships even though it is a build tool, and that is a judgement
 # rather than an oversight: it is 78KB, and it is the only way to recover a
 # printer whose database is wrong without rebuilding a package on a laptop.
-S6RC_BINS="s6-rc s6-rc-init s6-rc-db s6-rc-compile"
+S6RC_BINS="s6-rc s6-rc-init s6-rc-db s6-rc-compile s6-rc-update"
 S6RC_LIBEXEC="s6-rc-oneshot-run s6-rc-fdholder-filler"
 
 # shellcheck disable=SC2086

--- a/pkgs/3rdparty/s6-rc/control/postinst
+++ b/pkgs/3rdparty/s6-rc/control/postinst
@@ -1,0 +1,19 @@
+#!/bin/sh
+# Recompile the boot database after this package changes on a printer.
+#
+# s6-rc-compile writes the compiler's own execline shebang and oneshot runner
+# into every database it produces, so a database left behind by the previous
+# s6-rc is not one this s6-rc should be asked to run. anvil-core's postinst
+# covers the other half -- a change to the definitions themselves.
+#
+# A no-op until anvil-core is installed: the script lives in that package, and
+# opkg may land this one first.
+set -e
+
+MODDIR=/usr/data/anvil
+
+if [ -x "$MODDIR/bin/anvil-s6-rc-compile.sh" ]; then
+    "$MODDIR/bin/anvil-s6-rc-compile.sh"
+fi
+
+exit 0

--- a/pkgs/3rdparty/s6-rc/pkg.conf
+++ b/pkgs/3rdparty/s6-rc/pkg.conf
@@ -19,4 +19,9 @@ PKG_SECTION=base
 PKG_EXCLUDE=".version"
 PKG_DEPENDS="anvil-s6 anvil-execline"
 PKG_BUILD_DEPENDS="skalibs execline s6"
+# The only file of ours in this recipe is control/postinst, and the version
+# above cannot see it: without this, editing that script reports "already
+# current" and ships the previous .ipk. pkg_payload_hash covers control/ for
+# exactly this.
+PKG_STAMP_EXTRA="$(pkg_payload_hash)"
 PKG_DESCRIPTION="s6-rc, the service manager: a compiled dependency graph over s6's supervision, with the oneshot runner and fdholder filler its generated databases exec."

--- a/pkgs/3rdparty/sntpd/build.sh
+++ b/pkgs/3rdparty/sntpd/build.sh
@@ -1,20 +1,23 @@
 #!/usr/bin/env bash
 # sntpd -- cross-compiled for the printer. One autotools project, one binary.
 #
-# WHAT SHIPS IS $MODDIR/sbin/sntpd AND NOTHING ELSE. The tarball can install
-# two more programs, and both are left at their upstream default of off:
+# WHAT SHIPS IS THE BINARY AND ITS ntpclient NAME, both at $MODDIR/sbin.
 #
-#   adjtimex    --with-adjtimex. A kernel-clock tuning tool. Nothing here
-#               calls it and a printer is not where anybody debugs one.
-#   ntpclient   --with-ntpclient. A symlink to the same binary that makes it
-#               take Larry Doolittle's older option set instead. It is there
-#               for people with a script written against the ntpclient this
-#               project forked from; we have no such script, and shipping the
-#               second name would mean two documented spellings of one
-#               service.
-#
-# Neither is passed as --without-*, so this recipe states what it wants rather
-# than restating what upstream already decided.
+#   ntpclient   --with-ntpclient. A symlink to the same binary, which makes it
+#               take Larry Doolittle's older option set. THE ntp SERVICE EXECS
+#               THIS NAME, and has to: the step that sets the clock is
+#               `if (!dry && ntpc->set_clock)` at sntpd.c:485, and set_clock is
+#               raised in exactly one place -- the ntpclient argument parser,
+#               `case 's'` at sntpd.c:1459. sntpd's own parser initialises it
+#               to zero and has no option to raise it (its -s is logging), so
+#               under that name the daemon only ever disciplines the clock
+#               FREQUENCY through adjtimex. This printer has no RTC and boots
+#               in 1970; a frequency correction in parts per million does not
+#               close a fifty-six year gap, and the clock stays there for ever.
+#               Measured on a printer, 2026-08-31.
+#   adjtimex    --with-adjtimex, left at upstream's default of off. A
+#               kernel-clock tuning tool; nothing here calls it and a printer
+#               is not where anybody debugs one.
 set -euo pipefail
 . ./bin/common.sh
 . pkgs/lib.sh
@@ -37,10 +40,18 @@ pkg_unpack "$SNTPD_TGZ"
 # it (32-bit build, 64-bit inodes -- see versions.env).
 pkg_build "sntpd-$SNTPD_VERSION" \
     --build="$(uname -m)-linux-gnu" \
+    --with-ntpclient \
     CFLAGS="-O2 -D_FILE_OFFSET_BITS=64"
 
 # The man page is installed by `make install` into the staging tree and is not
 # shipped: pkg_ship copies what it is given, and $MODDIR/share/man on a printer
 # with no man reader is bytes in a 128MB partition.
-pkg_ship "sbin/sntpd"
+pkg_ship "sbin/sntpd" "sbin/ntpclient"
+
+# The symlink is upstream's install hook, and a `cp` that dereferenced it would
+# put a second 60KB binary in the package. Asserted because pkg_ship's copy is
+# the one place that could quietly change.
+[ -L "$PKG_OUT/sbin/ntpclient" ] || pkg_die \
+    "sntpd: sbin/ntpclient is not a symlink -- the package carries the binary twice"
+
 pkg_end

--- a/pkgs/anvil-core/build.sh
+++ b/pkgs/anvil-core/build.sh
@@ -29,10 +29,13 @@
 # that links them there: payload/bin/anvil-link-prog.sh.
 #
 # THE s6-rc SERVICE SOURCE IS HERE and is not compiled by this recipe.
-# payload/etc/s6-rc/source/ is text; the replica runs s6-rc-compile over it
-# once the payload is assembled, so this package stays buildable on a checkout
-# that has never run a cross-compiler. Giving it PKG_BUILD_DEPENDS="s6-rc"
-# would take that away.
+# payload/etc/s6-rc/source/ is text, and payload/bin/anvil-s6-rc-compile.sh is
+# what turns it into a database: the replica calls that script once the payload
+# is assembled, and this package's postinst calls it again on a printer, so an
+# `opkg upgrade` of these definitions changes what the next boot runs. The
+# recipe itself compiles nothing, which is what keeps it buildable on a
+# checkout that has never run a cross-compiler. Giving it
+# PKG_BUILD_DEPENDS="s6-rc" would take that away.
 set -euo pipefail
 . ./bin/common.sh
 . pkgs/lib.sh

--- a/pkgs/anvil-core/control/postinst
+++ b/pkgs/anvil-core/control/postinst
@@ -1,14 +1,29 @@
 #!/bin/sh
-# Re-point the stock boot path after `opkg upgrade anvil-core` on a printer.
-# Without it the upgrade writes a new $MODDIR/prog/firmwareExe and the printer
-# goes on running the copy /usr/prog already had.
+# Put the printer on what this package just installed.
 #
-# The same script runs from installer/runFirmwareExe.sh on the .tgz path. Its own
-# /usr/prog/app_startup.sh guard is what makes this a no-op when the build
-# installs this package rather than a printer.
+# Two things an unpacked package is not enough for, both because what the
+# printer reads is generated or symlinked rather than shipped:
+#
+#   the boot path      $MODDIR/prog/firmwareExe is a new file, and /usr/prog
+#                      goes on running the copy it already had
+#   the boot database  etc/s6-rc/source/ is text, and the database the last
+#                      boot used was compiled from the PREVIOUS definitions --
+#                      so a changed or added service would not reach the
+#                      printer at all
+#
+# The same two scripts run from installer/runFirmwareExe.sh on the .tgz path.
+# Their own guards are what make this a no-op when the build installs this
+# package rather than a printer.
 set -e
 
 MODDIR=/usr/data/anvil
-[ -x "$MODDIR/bin/anvil-link-prog.sh" ] || exit 0
-"$MODDIR/bin/anvil-link-prog.sh"
+
+if [ -x "$MODDIR/bin/anvil-link-prog.sh" ]; then
+    "$MODDIR/bin/anvil-link-prog.sh"
+fi
+
+if [ -x "$MODDIR/bin/anvil-s6-rc-compile.sh" ]; then
+    "$MODDIR/bin/anvil-s6-rc-compile.sh"
+fi
+
 exit 0

--- a/pkgs/anvil-core/payload/bin/anvil-s6-rc-compile.sh
+++ b/pkgs/anvil-core/payload/bin/anvil-s6-rc-compile.sh
@@ -23,21 +23,9 @@
 # that was current is kept, so a printer that will not boot the new one still
 # has the old one on disk to point `current` back at.
 #
-# THE LIVE STATE HAS TO BE RECONCILED, not left alone. s6-rc-init writes
-# /run/s6-rc/state as one byte per service in the database it booted, and
-# /run/s6-rc/compiled is a symlink to compiled/current -- so moving `current`
-# under a running system leaves a state file whose size no longer matches the
-# database, and every `s6-rc` command fails with "unable to read valid state"
-# until the next boot. Supervision itself survives (s6-svscan and s6-supervise
-# are a separate mechanism, and s6-svstat/s6-svc keep working), which is what
-# makes the breakage quiet enough to ship without noticing. It shipped once,
-# 2026-08-31.
-#
-# s6-rc-update is the supported answer: it migrates the live state onto the new
-# database, leaving services whose definitions did not change running. Ones
-# that DID change are restarted, which is the honest cost of applying an
-# upgrade to a running machine -- and is why an upgrade is not a thing to do
-# mid-print.
+# A NEW DATABASE REACHES THE PRINTER AT THE NEXT BOOT, not when this runs.
+# Nothing running is stopped or started; the cost is that `s6-rc` itself is
+# unusable in between, which the tail of this script explains.
 set -e
 
 MODDIR=${MODDIR:-/usr/data/anvil}
@@ -75,30 +63,33 @@ rm -rf "$COMPILED/$DB"
 "$COMPILE" "$COMPILED/$DB" "$SRC"
 echo "s6-rc-compile: $DB -- $(ls "$SRC" | wc -l) definitions"
 
-# Reconcile a running system BEFORE `current` moves. s6-rc-update reads the
-# database the live directory is on to know what it is migrating FROM, and
-# /run/s6-rc/compiled is a symlink to compiled/current -- so flipping first
-# leaves it comparing the new database against itself. Ask the migration to
-# happen while the old database is still the current one.
-#
-# LIVE's absence is the ordinary case: the payload build, and a printer that
-# has not booted this far. A failure is reported and not fatal -- the database
-# on disk is right either way, and a reboot applies it.
-LIVE=/run/s6-rc
-UPDATE=$MODDIR/bin/s6-rc-update
-if [ -d "$LIVE" ] && [ -x "$UPDATE" ]; then
-    if "$UPDATE" -l "$LIVE" "$COMPILED/$DB"; then
-        echo "s6-rc-compile: live state migrated to $DB"
-    else
-        echo "s6-rc-compile: !! could not migrate the live state to $DB" >&2
-        echo "s6-rc-compile:    reboot to come up on it" >&2
-    fi
-elif [ -d "$LIVE" ]; then
-    echo "s6-rc-compile: no $UPDATE -- reboot to come up on $DB"
-fi
-
-# Now the next boot's database, whatever the migration did.
 ln -sfn "$DB" "$COMPILED/current"
+
+# THE LIVE STATE IS NOT MIGRATED, AND THIS IS NOT AN OVERSIGHT. Moving
+# `current` under a running system leaves /run/s6-rc/state -- one byte per
+# service in the database that booted -- the wrong size for the database
+# /run/s6-rc/compiled now resolves to, so `s6-rc` reports "unable to read
+# valid state" until the next boot. Supervision is a separate mechanism and
+# keeps every service running, so the printer is fine; only s6-rc itself is
+# unusable in the window.
+#
+# s6-rc-update exists to close that window and IS SHIPPED, for a hand at a
+# prompt. It is not called from here because on this machine it does not work:
+# from a state that had just booted cleanly it failed with
+#
+#     s6-rc-update: fatal: unable to manage new service directories
+#                   in /run/s6-rc: Value too large for defined data type
+#
+# having ALREADY emptied the scandir -- every symlink under $MODDIR/etc/s6
+# gone, while the supervisors it had started were still running. The next
+# s6-svscan rescan would have taken down klipper, the UI and wifi together.
+# An upgrade that can do that is worse than an s6-rc you cannot drive until
+# you reboot. (Measured 2026-08-31; EOVERFLOW despite -D_FILE_OFFSET_BITS=64
+# through skalibs, s6, execline and s6-rc, so the cause is not the obvious
+# one and wants finding before this is wired up again.)
+if [ -d /run/s6-rc ]; then
+    echo "s6-rc-compile: reboot to come up on $DB"
+fi
 
 # Prune. `continue` is written as a full if rather than `[ x ] && continue`,
 # which under set -e exits the script the first time the test is false.

--- a/pkgs/anvil-core/payload/bin/anvil-s6-rc-compile.sh
+++ b/pkgs/anvil-core/payload/bin/anvil-s6-rc-compile.sh
@@ -23,10 +23,21 @@
 # that was current is kept, so a printer that will not boot the new one still
 # has the old one on disk to point `current` back at.
 #
-# NOTHING LIVE IS TOUCHED. s6-rc reads the database at boot; a running
-# supervision tree keeps the one it started with until the printer is
-# rebooted. That is deliberate -- switching a live tree over would restart
-# services, and an `opkg upgrade` is not a thing that should stop a print.
+# THE LIVE STATE HAS TO BE RECONCILED, not left alone. s6-rc-init writes
+# /run/s6-rc/state as one byte per service in the database it booted, and
+# /run/s6-rc/compiled is a symlink to compiled/current -- so moving `current`
+# under a running system leaves a state file whose size no longer matches the
+# database, and every `s6-rc` command fails with "unable to read valid state"
+# until the next boot. Supervision itself survives (s6-svscan and s6-supervise
+# are a separate mechanism, and s6-svstat/s6-svc keep working), which is what
+# makes the breakage quiet enough to ship without noticing. It shipped once,
+# 2026-08-31.
+#
+# s6-rc-update is the supported answer: it migrates the live state onto the new
+# database, leaving services whose definitions did not change running. Ones
+# that DID change are restarted, which is the honest cost of applying an
+# upgrade to a running machine -- and is why an upgrade is not a thing to do
+# mid-print.
 set -e
 
 MODDIR=${MODDIR:-/usr/data/anvil}
@@ -59,11 +70,35 @@ PREV=$(readlink "$COMPILED/current" 2>/dev/null || true)
 mkdir -p "$COMPILED"
 rm -rf "$COMPILED/$DB"
 
-# Compile first, flip second. A half-written database that `current` never
-# pointed at is one the next boot ignores; the reverse loses the printer.
+# Compile into its final name. Nothing points at it yet, so a half-written
+# database is one the next boot ignores.
 "$COMPILE" "$COMPILED/$DB" "$SRC"
-ln -sfn "$DB" "$COMPILED/current"
 echo "s6-rc-compile: $DB -- $(ls "$SRC" | wc -l) definitions"
+
+# Reconcile a running system BEFORE `current` moves. s6-rc-update reads the
+# database the live directory is on to know what it is migrating FROM, and
+# /run/s6-rc/compiled is a symlink to compiled/current -- so flipping first
+# leaves it comparing the new database against itself. Ask the migration to
+# happen while the old database is still the current one.
+#
+# LIVE's absence is the ordinary case: the payload build, and a printer that
+# has not booted this far. A failure is reported and not fatal -- the database
+# on disk is right either way, and a reboot applies it.
+LIVE=/run/s6-rc
+UPDATE=$MODDIR/bin/s6-rc-update
+if [ -d "$LIVE" ] && [ -x "$UPDATE" ]; then
+    if "$UPDATE" -l "$LIVE" "$COMPILED/$DB"; then
+        echo "s6-rc-compile: live state migrated to $DB"
+    else
+        echo "s6-rc-compile: !! could not migrate the live state to $DB" >&2
+        echo "s6-rc-compile:    reboot to come up on it" >&2
+    fi
+elif [ -d "$LIVE" ]; then
+    echo "s6-rc-compile: no $UPDATE -- reboot to come up on $DB"
+fi
+
+# Now the next boot's database, whatever the migration did.
+ln -sfn "$DB" "$COMPILED/current"
 
 # Prune. `continue` is written as a full if rather than `[ x ] && continue`,
 # which under set -e exits the script the first time the test is false.

--- a/pkgs/anvil-core/payload/bin/anvil-s6-rc-compile.sh
+++ b/pkgs/anvil-core/payload/bin/anvil-s6-rc-compile.sh
@@ -1,0 +1,82 @@
+#!/bin/sh
+# Compile the s6-rc boot database from the service definitions, and point
+# `current` at the result.
+#
+# THE DATABASE IS GENERATED, NOT SHIPPED. anvil-core carries
+# etc/s6-rc/source/ as text -- see its build.sh for why the recipe does not
+# compile it -- so something has to run s6-rc-compile over that tree before a
+# boot can use it. On the .tgz path that something is the payload build; on a
+# printer it is the postinst of each package that can change the answer:
+#
+#   anvil-core    owns the definitions
+#   anvil-s6-rc   owns the compiler, whose execline shebang and oneshot runner
+#                 every database it writes bakes in
+#
+# All three call this file, so there is one implementation of the compile
+# rather than one per caller.
+#
+#     anvil-s6-rc-compile.sh [db-name]
+#
+# WITH A NAME the compile is deterministic and every other database is removed:
+# that is the payload build, whose output has to be byte-identical between two
+# builds of one commit. WITHOUT ONE the name is a timestamp and the database
+# that was current is kept, so a printer that will not boot the new one still
+# has the old one on disk to point `current` back at.
+#
+# NOTHING LIVE IS TOUCHED. s6-rc reads the database at boot; a running
+# supervision tree keeps the one it started with until the printer is
+# rebooted. That is deliberate -- switching a live tree over would restart
+# services, and an `opkg upgrade` is not a thing that should stop a print.
+set -e
+
+MODDIR=${MODDIR:-/usr/data/anvil}
+SRC=$MODDIR/etc/s6-rc/source
+COMPILED=$MODDIR/etc/s6-rc/compiled
+COMPILE=$MODDIR/bin/s6-rc-compile
+
+WANT=${1:-}
+
+# Not an error, and not a guess about install order: opkg runs the two
+# postinsts in whichever order the dependency graph gives it, and the first of
+# them has only half of what a compile needs. The second does the work.
+if [ ! -d "$SRC" ]; then
+    echo "s6-rc-compile: no $SRC yet -- nothing to compile"
+    exit 0
+fi
+if [ ! -x "$COMPILE" ]; then
+    echo "s6-rc-compile: no $COMPILE yet -- nothing to compile with"
+    exit 0
+fi
+
+if [ -n "$WANT" ]; then
+    DB=$WANT
+else
+    DB=db-$(date +%Y%m%d%H%M%S)
+fi
+
+PREV=$(readlink "$COMPILED/current" 2>/dev/null || true)
+
+mkdir -p "$COMPILED"
+rm -rf "$COMPILED/$DB"
+
+# Compile first, flip second. A half-written database that `current` never
+# pointed at is one the next boot ignores; the reverse loses the printer.
+"$COMPILE" "$COMPILED/$DB" "$SRC"
+ln -sfn "$DB" "$COMPILED/current"
+echo "s6-rc-compile: $DB -- $(ls "$SRC" | wc -l) definitions"
+
+# Prune. `continue` is written as a full if rather than `[ x ] && continue`,
+# which under set -e exits the script the first time the test is false.
+for _d in "$COMPILED"/db-*; do
+    [ -d "$_d" ] || continue
+    _n=$(basename "$_d")
+    if [ "$_n" = "$DB" ]; then
+        continue
+    fi
+    if [ -z "$WANT" ] && [ "$_n" = "$PREV" ]; then
+        continue
+    fi
+    rm -rf "$_d"
+done
+
+exit 0

--- a/pkgs/anvil-core/payload/etc/s6-rc/source/klipper/run
+++ b/pkgs/anvil-core/payload/etc/s6-rc/source/klipper/run
@@ -1,59 +1,45 @@
 #!/bin/sh
 # Klippy, as s6 supervises it. Exec'd by s6-supervise, never by hand.
 #
-# This is FlashForge's klipperDaemon command line without the -b: without it
-# busybox start-stop-daemon execs the program in place, so the process
-# s6-supervise holds IS klippy rather than a shell that started one. The
-# pidfile goes with it -- s6-supervise knows the pid.
+# The process this script becomes IS the service, so it ends in one `exec` and
+# everything above that is preparation. s6-supervise is the parent: it knows the
+# pid, runs one copy of this servicedir at a time, and restarts what dies. So no
+# forking, no pidfile, and no "is one already running?" test.
 #
 # THE MCU BRING-UP DOES NOT HAPPEN HERE. It is the `mcu-bringup` oneshot, which
-# klipper depends on, so s6-rc runs it before this service starts. Doing it
-# here as well would hand the same serial ports to two processes at once.
+# klipper depends on, so s6-rc runs it first. Doing it here as well would hand
+# the same serial ports to two processes at once.
 MODDIR=/usr/data/anvil
 
-# anvil-env.sh names the interpreter ($FF_PYTHON) and puts the mod's four
-# library directories on LD_LIBRARY_PATH. s6-supervise hands this script the
-# scanner's environment, which is already correct on the boot path -- but a
-# service must not work only because the shell that started the tree happened
-# to be set up right.
+# READ, NOT INHERITED: s6-supervise hands this script the SCANNER's environment,
+# which is firmwareExe's at boot but whatever an ssh session had on a restart by
+# hand. anvil-env.sh names $FF_PYTHON and sets LD_LIBRARY_PATH.
 if [ -f $MODDIR/anvil-env.sh ]; then
     . $MODDIR/anvil-env.sh
 else
     echo "klipper/run: !! no $MODDIR/anvil-env.sh -- klippy will not find its libraries"
 fi
 
-# BOTH HALVES ARE OURS AND BOTH ARE UNDER $MODDIR: the klippy tree anvil-klipper
-# installs, on the CPython 3.13 anvil-python installs. There is no /usr/prog in
-# this command line any more.
-#
-# The tree used to be read from /usr/prog/klipper/klippy -- a copy bin/payload.sh
-# staged into the software component out of this very package, so that
-# FlashForge's run.sh would place it on the firmware partition. Two copies of
-# one tree, and the one that ran was the one a stock flash could overwrite.
-# anvil-klipper is the only source now, which is also what lets this package
-# declare the interpreter it actually needs: see pkgs/klipper/pkg.conf.
-#
-# THE INTERPRETER IS NOT FLASHFORGE'S 3.8.2 and has not been since $FF_PYTHON
-# moved to 3.13. klippy reaches c_helper.so through _cffi_backend, which is why
-# pkgs/3rdparty/python is a glibc build and not a musl one.
+# Both halves are ours and both are under $MODDIR -- nothing is read from
+# /usr/prog, the partition a stock flash overwrites. klippy reaches c_helper.so
+# through _cffi_backend, which is why pkgs/3rdparty/python is glibc, not musl.
 KLIPPY=$MODDIR/klipper/klippy/klippy.py
 PRINTER_CFG=/usr/data/config/printer.cfg
 PRINTER_LOG=/usr/data/logs/printer.log
 UDS=/tmp/uds
 
-# klippy does not unlink its socket on exit, and everything on this printer
-# reads that socket as "klipper is running". Swept here rather than in a stop()
-# because s6 restarts this service without going near one.
+# klippy does not unlink its socket on exit, and everything here reads that
+# socket as "klipper is running". Swept on the way in because s6 restarts this
+# service without going near a stop().
 rm -f "$UDS"
 
-# A klippy killed with SIGKILL -- an OOM -- leaves a process still holding
-# /dev/ttyS4 while s6 starts a second one that cannot open the port and reports
-# an MCU error for ever. s6-supervise runs one copy of this service at a time,
-# so anything running klippy.py now is a leftover.
+# THE ONE DUPLICATE s6 CANNOT HANDLE: a klippy that outlived its supervisor. An
+# OOM kill leaves it holding /dev/ttyS4 while s6 starts a second one that cannot
+# open the port and reports an MCU error for ever.
 #
-# /proc rather than `ps | grep`: busybox ps truncates to the terminal width, so
-# the command line arrives cut off and the grep matches nothing. Our own pid is
-# skipped.
+# Matched on klippy.py -- the interpreter would match moonraker, which runs
+# $FF_PYTHON too. /proc rather than `ps | grep`, whose output busybox truncates
+# to the terminal width.
 for _kl_proc in /proc/[0-9]*; do
     [ -r "$_kl_proc/cmdline" ] || continue
     [ "${_kl_proc#/proc/}" = "$$" ] && continue
@@ -63,9 +49,8 @@ for _kl_proc in /proc/[0-9]*; do
 done
 unset _kl_proc
 
-# klipper_pri.sh puts klippy's main thread on SCHED_FIFO 50. It cannot run
-# before the exec below -- there would be no klippy to find -- and this script
-# has no "after", so it waits for the socket that says klippy is serving.
+# klipper_pri.sh puts klippy's main thread on SCHED_FIFO 50, so it has to run
+# after the exec below; this waits for the socket that says klippy is serving.
 # Bounded, and nothing reads the result: a missing chrt is a slower printer.
 if [ -x /usr/prog/klipper/klipper_pri.sh ]; then
     (   _kp=0
@@ -77,16 +62,5 @@ if [ -x /usr/prog/klipper/klipper_pri.sh ]; then
     ) >/dev/null 2>&1 &
 fi
 
-# NO NICE VALUE: klippy runs at normal priority, which is what FlashForge
-# shipped. The number was briefly a NICE_KLIPPER knob in anvil.conf, and before
-# that the installer grepped KLIPPER_NICENESS out of the stock klipperDaemon --
-# which is what made that shim machine-specific and kept it from being a symlink
-# like the other two files in prog/. Neither is true now.
-#
-# Renicing klippy is nearly always the wrong lever anyway: klipper_pri.sh puts
-# its main thread on SCHED_FIFO 50, which outranks every nice value there is,
-# and its serial reader thread calls os.nice(-20) itself. The two services that
-# DO carry a nice value are the ones that yield to klippy -- moonraker/run and
-# camera/run, each stating its own.
-exec start-stop-daemon -S --exec "$FF_PYTHON" -- \
-    "$KLIPPY" "$PRINTER_CFG" -l "$PRINTER_LOG" -a "$UDS"
+# No nice value: SCHED_FIFO 50 above outranks every nice value there is.
+exec "$FF_PYTHON" "$KLIPPY" "$PRINTER_CFG" -l "$PRINTER_LOG" -a "$UDS"

--- a/pkgs/anvil-core/payload/etc/s6-rc/source/ntp/run
+++ b/pkgs/anvil-core/payload/etc/s6-rc/source/ntp/run
@@ -18,11 +18,24 @@
 #   * A clock is not set once. There is no RTC to hold the answer, so the
 #     correction has to be maintained for as long as the printer is up.
 #
-# sntpd does both by design: with the network down it logs "will try again
-# later" and keeps its schedule, rather than exiting, so THIS SERVICE NEEDS NO
-# WIFI DEPENDENCY -- and would gain nothing from one, because `wifi` up means
-# a supplicant is running, not that anything is routable. It syncs whenever
-# the network turns up, from whichever direction.
+# The binary does both by design: with the network down it logs "will try
+# again later" and keeps its schedule, rather than exiting, so THIS SERVICE
+# NEEDS NO WIFI DEPENDENCY -- and would gain nothing from one, because `wifi`
+# up means a supplicant is running, not that anything is routable. It syncs
+# whenever the network turns up, from whichever direction.
+#
+# IT IS EXEC'D AS ntpclient, WHICH IS THE ONLY NAME THAT SETS THE CLOCK. Both
+# names are the same binary and it chooses its argument parser from argv[0].
+# The step lives behind `if (!dry && ntpc->set_clock)` at sntpd.c:485, and
+# set_clock is raised in one place only: `case 's'` in the ntpclient parser,
+# sntpd.c:1459. Under the sntpd name that field is initialised to zero with no
+# option to raise it -- its -s means "log to syslog" -- and the daemon
+# disciplines the clock FREQUENCY through adjtimex instead. That is the right
+# behaviour for a machine whose clock is roughly right and drifting. It is
+# useless here: there is no RTC, every boot starts in 1970, and a correction
+# in parts per million never closes fifty-six years. Run as sntpd this service
+# resolved, connected, took valid stratum-1 readings and left the clock in
+# 1970 for as long as the printer was up (measured 2026-08-31).
 MODDIR=/usr/data/anvil
 
 # anvil-env.sh is read HERE, not inherited. s6-supervise starts this script
@@ -30,7 +43,9 @@ MODDIR=/usr/data/anvil
 # an ssh session had when the service is restarted by hand.
 [ -f $MODDIR/anvil-env.sh ] && . $MODDIR/anvil-env.sh
 
-SNTPD=$MODDIR/sbin/sntpd
+# The ntpclient name of the anvil-sntpd binary. Both names are one file; this
+# is the one whose argument parser can set the clock.
+NTPCLIENT=$MODDIR/sbin/ntpclient
 LOG=/usr/data/logs/anvil-ntp.log
 
 # ---- the whole policy, which is an argument list -------------------------
@@ -65,21 +80,31 @@ exec >>"$LOG" 2>&1
 # unattended, rather than failing an exec once a second. The sleep is a minute
 # rather than the five seconds the other services use because a removed
 # package is a permanent condition, not a race.
-if [ ! -x "$SNTPD" ]; then
-    echo "ntp: !! no $SNTPD -- anvil-sntpd is not installed, the clock stays wrong"
+if [ ! -x "$NTPCLIENT" ]; then
+    echo "ntp: !! no $NTPCLIENT -- anvil-sntpd is not installed, the clock stays wrong"
     sleep 60
     exit 1
 fi
 
-# -n  Do not fork: the process this script turns into IS the service. Without
-#     it s6-supervise would hold a process that exited immediately, call the
-#     service dead, and respawn it forever beside a real sntpd supervised by
-#     nobody. It also puts the log on stdout, which is the redirection above.
+# THE OPTIONS BELOW ARE THE ntpclient SET, NOT sntpd's, and the two disagree
+# about the same letters. Read them against sntpd.c:1416, not against
+# `sntpd -h`:
 #
-# -p 0  NO SERVER MODE. sntpd answers NTP queries on UDP 123 by default. A
-#     3D printer on somebody's home LAN has no business being a time source --
-#     least of all this one, whose own clock is whatever it last read.
+# -s  Set the clock. The whole reason this name is exec'd; see above.
 #
-# And `exec`, so the SIGTERM behind `s6-rc -d change ntp` reaches sntpd rather
-# than a shell that ignores it.
-exec "$SNTPD" -n -p 0 -i "$INTERVAL" $SERVERS
+# -l  Live: keep polling and keep disciplining the frequency between steps,
+#     rather than exiting after the first reading. With -g and -c both unset
+#     the "stop setting the clock once it is good" branch at sntpd.c:1229
+#     never fires, so a printer that drifts is corrected again, for ever.
+#
+# -h  The server. Repeatable; one pool entry is enough, for the reason above.
+#
+# NO -n AND NO -p HERE. This parser has no -n at all -- an unknown option is a
+# usage error and a service that exits at once -- and it does not need one:
+# ntpclient mode does not fork and logs to stdout, which is the redirection
+# above. Its -p is the LOCAL port to send from, not sntpd's server-mode port;
+# server mode is already off, because only the sntpd parser turns it on.
+#
+# And `exec`, so the SIGTERM behind `s6-rc -d change ntp` reaches the daemon
+# rather than a shell that ignores it.
+exec "$NTPCLIENT" -s -l -i "$INTERVAL" -h "$SERVERS"

--- a/pkgs/klipper-config/control/postinst
+++ b/pkgs/klipper-config/control/postinst
@@ -1,0 +1,23 @@
+#!/bin/sh
+# Link the configs this package ships into /usr/data/config, where Klipper
+# reads them.
+#
+# WHY THIS PACKAGE NEEDS ITS OWN. What printer.cfg includes are the ff-*.cfg
+# beside it, and anvil-link-prog.sh makes one symlink per file it finds in
+# $MODDIR/config. anvil-core's postinst calls that script too -- but anvil-core
+# does not own these files, and opkg installs it first: on an upgrade that ADDS
+# an ff-*.cfg, the link pass ran before the new file existed, so Klipper
+# refused to start on an include that had nothing behind it. That is not
+# hypothetical; ff-pa.cfg did exactly this on a printer, 2026-08-31.
+#
+# Re-running the script is cheap and quiet: link_one leaves a link that is
+# already right alone.
+set -e
+
+MODDIR=/usr/data/anvil
+
+if [ -x "$MODDIR/bin/anvil-link-prog.sh" ]; then
+    "$MODDIR/bin/anvil-link-prog.sh"
+fi
+
+exit 0

--- a/qa/static/test_s6_run_scripts.py
+++ b/qa/static/test_s6_run_scripts.py
@@ -1,0 +1,63 @@
+"""An s6 `run` script must not launch its daemon through start-stop-daemon.
+
+THE BUG THIS EXISTS FOR. `klipper/run` launched klippy with
+
+    exec start-stop-daemon -S --exec "$FF_PYTHON" -- "$KLIPPY" ...
+
+`-S` starts the program *unless a matching process is found*, and `--exec`
+matches on the interpreter rather than on the script. moonraker runs
+$FF_PYTHON too, so start-stop-daemon found moonraker, reported the service
+already up, and returned without ever exec'ing klippy. s6 saw a longrun exit
+and respawned it, for as long as the printer was on: moonraker up, klipper
+`disconnected`, ff-startup giving up with KLIPPER DID NOT FINISH STARTING, and
+HelixScreen in front of a machine with no motion and no heaters.
+
+WHY THIS IS STATIC AND NOT A REPLICA TEST, which is the exception this file has
+to earn. The replica CANNOT reproduce it. Printer binaries run there under
+qemu-mipsel-static, so a moonraker process has
+
+    cmdline[0] = /usr/bin/qemu-mipsel-static
+    /proc/PID/exe -> /usr/bin/qemu-mipsel-static
+
+and start-stop-daemon, matching on $FF_PYTHON, therefore matches nothing and
+starts klippy exactly as it should. MEASURED: a replica built from a package
+carrying the broken line passes a behaviour test that asserts klippy starts
+with moonraker up. Emulation rewrites the process identity the bug depends on,
+so the one lane that runs the real tools is blind to it by construction, and a
+behaviour test there would be worse than none -- it would report this very
+failure as green.
+
+THE RULE, therefore, rather than the symptom: an s6 run script execs its daemon
+and nothing else. s6-supervise is the parent -- it knows the pid, runs one copy
+of a servicedir at a time, and restarts what dies -- so a "is one already
+running?" check in a run script has no true positive left to find and can only
+return false ones. moonraker/run states the same rule in prose at its head.
+"""
+import pytest
+
+from lib.paths import ROOT
+
+pytestmark = pytest.mark.static
+
+RUN_SCRIPTS = sorted(ROOT.glob("pkgs/*/payload/etc/s6-rc/source/*/run"))
+
+
+def test_there_are_run_scripts_to_check():
+    """A glob that matches nothing would make every test below vacuous."""
+    assert RUN_SCRIPTS, "no s6-rc run scripts found under pkgs/*/payload"
+
+
+@pytest.mark.parametrize(
+    "run", RUN_SCRIPTS, ids=lambda p: p.parent.name)
+def test_no_start_stop_daemon(run):
+    """Code, not comments: moonraker/run and klipper/run both DISCUSS
+    start-stop-daemon at length, and saying why it is absent must stay
+    allowed."""
+    offending = [
+        line for line in run.read_text().splitlines()
+        if "start-stop-daemon" in line and not line.lstrip().startswith("#")
+    ]
+    assert not offending, (
+        "%s launches through start-stop-daemon: %s\n"
+        "s6-supervise is the parent -- exec the daemon directly."
+        % (run.parent.name, offending))

--- a/tools/replica/printer/case-build-payload.sh
+++ b/tools/replica/printer/case-build-payload.sh
@@ -57,15 +57,20 @@ echo "payload: $($OPKG list-installed | wc -l) packages installed"
 # compiled/<stamp> with `current` a symlink, so the boot command never changes
 # when the database does. Not s6-rc-init's default /etc/s6-rc/, which is
 # inside the read-only squashfs.
+#
+# THROUGH THE SCRIPT anvil-core SHIPS, which the postinsts of anvil-core and
+# anvil-s6-rc also call, so an `opkg upgrade` on a printer compiles the
+# database the same way this does. Naming the database here is what keeps the
+# payload reproducible: given a name the script removes every other database,
+# so the timestamped ones those postinsts just wrote do not ship.
 S6RC_SRC=$PREFIX/etc/s6-rc/source
 S6RC_DB=db-${MOD_VER:-0}
+S6RC_COMPILE=$PREFIX/bin/anvil-s6-rc-compile.sh
 [ -d "$S6RC_SRC" ] || { echo "payload: no s6-rc source at $S6RC_SRC -- anvil-core did not install" >&2; exit 1; }
 [ -x $PREFIX/bin/s6-rc-compile ] || { echo "payload: no $PREFIX/bin/s6-rc-compile -- anvil-s6-rc did not install" >&2; exit 1; }
-rm -rf $PREFIX/etc/s6-rc/compiled
-mkdir -p $PREFIX/etc/s6-rc/compiled
-$PREFIX/bin/s6-rc-compile $PREFIX/etc/s6-rc/compiled/$S6RC_DB "$S6RC_SRC" \
+[ -x "$S6RC_COMPILE" ] || { echo "payload: no $S6RC_COMPILE -- anvil-core did not install" >&2; exit 1; }
+"$S6RC_COMPILE" "$S6RC_DB" \
     || { echo "payload: s6-rc-compile refused $S6RC_SRC" >&2; exit 1; }
-ln -sfn $S6RC_DB $PREFIX/etc/s6-rc/compiled/current
 echo "payload: s6-rc database $S6RC_DB compiled -- `ls "$S6RC_SRC" | wc -l` definitions"
 
 # --- make it shippable -----------------------------------------------------


### PR DESCRIPTION
Five fixes found by upgrading a printer with `opkg` rather than a USB stick, each one verified on the machine.

## The boot database is compiled on the printer (`15aa6ab`)

`etc/s6-rc/source` is text and only the payload build ever ran `s6-rc-compile` over it, so `opkg upgrade anvil-core` wrote new service definitions and left the printer booting the database built from the old ones. anvil-core ships `bin/anvil-s6-rc-compile.sh` and its postinst calls it; anvil-s6-rc calls it too, because a database bakes in the compiler's own execline shebang. The payload build calls the same script rather than its own copy of the compile.

`anvil-s6-rc` gains `PKG_STAMP_EXTRA`: its version comes from the tarball and cannot see `control/postinst`.

## klipper-config links the configs it ships (`9fcfaa4`)

The `ff-*.cfg` in `/usr/data/config` are symlinks made by `anvil-link-prog.sh`, and only anvil-core called it — a package that does not own those files and that opkg installs first. An upgrade adding an `ff-*.cfg` linked the old set, and Klipper refused to start:

```
Include file '/usr/data/config/ff-pa.cfg' does not exist
```

The package that ships the files now relinks them. Verified by deleting the link on a printer and watching the reinstall restore it.

## s6-rc-update ships (`dda4eb4`), but the compile does not drive it (`2be2de2`)

Moving `current` under a running system leaves `/run/s6-rc/state` the wrong size for the database it now resolves to, so `s6-rc` fails with "unable to read valid state" until the next boot. Supervision is a separate mechanism and keeps every service up, which is what makes it quiet.

`s6-rc-update` is the supported answer and now ships — but it is **not** called automatically, because on the printer it fails from a clean live state with

```
s6-rc-update: fatal: unable to manage new service directories
              in /run/s6-rc: Value too large for defined data type
```

having already emptied the scandir, while the supervisors it started keep running. The next `s6-svscan` rescan would take down klipper, the UI and wifi together. The EOVERFLOW is not the obvious missing largefile flag — skalibs, s6, execline and s6-rc all pass `-D_FILE_OFFSET_BITS=64` — and wants finding before this is wired up again.

## The ntp service execs `ntpclient` (`e3d5a62`)

`sntpd` and `ntpclient` are one binary choosing its parser from `argv[0]`, and only one of them can step the clock:

```c
if (!dry && ntpc->set_clock)          /* sntpd.c:485 */
```

`set_clock` is raised in exactly one place — `case 's'` in the ntpclient parser, `sntpd.c:1459`. Under the sntpd name it is zero with no option to raise it (that parser's `-s` is syslog), and the daemon only disciplines clock *frequency* through adjtimex. On a printer with no RTC that boots in 1970, parts per million never close fifty-six years.

So the service never worked: it resolved, connected, took valid stratum-1 readings, and left the clock in 1970 — healthy by every signal except the one that matters. The recipe now passes `--with-ntpclient` (upstream's install hook, a symlink, asserted so the package cannot carry the binary twice) and the run script execs that name with `-s -l`. The option block is rewritten against the right parser: the two disagree about `-p`, and `-n` does not exist there at all.

Verified on the printer: clock forced back two hours, service restarted, correct again twenty seconds later.

## Checks

`make qa-static` — 154 passed, 3 skipped. All five changes installed and exercised on a Creator5Pro; it now runs Klipper `ready` with `s6-rc -a list` reporting 11 services up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AVUMfbNuKUWWV32PBcydwb