### PR TITLE
The chamber heater's fan follows the heater, not the touchscreen

### DIFF
--- a/bin/unpack.sh
+++ b/bin/unpack.sh
@@ -48,9 +48,18 @@ echo "$SRC"          > work/.source_pkg
 STOCK_BASE=work/software/klipper/config/printer.base.cfg
 OURS=pkgs/klipper-config/prog/config/printer.base.cfg
 if [ -f "$STOCK_BASE" ] && [ -f "$OURS" ]; then
-    # Section/option lines only: comments differ by design, and the chamber
-    # and ff-*.cfg includes are ours.
-    strip() { grep -vE '^\s*(#|$)' "$1" | grep -vE '^\[(heater_generic|verify_heater) chamber_heater\]|^\[include printer\.chamber\.cfg\]|^\[include ff-[a-z-]+\.cfg\]'; }
+    # Section/option lines only: comments differ by design, and the includes we
+    # add are ours. The sections we MOVED to printer.chamber.cfg have to go as
+    # whole blocks -- dropping just their headers left their option lines in
+    # the stock side and nothing to match them, so this always reported drift.
+    strip() {
+        grep -vE '^\s*(#|$)' "$1" \
+        | awk '
+            /^\[/ { drop = ($0 ~ /^\[(heater_generic|verify_heater) chamber_heater\]|^\[fan_generic chamber_heat_fan\]/) }
+            !drop
+          ' \
+        | grep -vE '^\[include (printer\.chamber|timelapse|ff-[a-z-]+)\.cfg\]'
+    }
     if strip "$STOCK_BASE" | diff -q - <(strip "$OURS") >/dev/null 2>&1; then
         echo ">> printer.base.cfg matches the stock file"
     else

--- a/pkgs/klipper-config/payload/config/chamber/Creator5.cfg
+++ b/pkgs/klipper-config/payload/config/chamber/Creator5.cfg
@@ -25,3 +25,17 @@ sensor_type:Generic 3950
 sensor_pin:PC1
 min_temp:-100
 max_temp:80
+
+# The heating element's fan (PD12), FlashForge's section verbatim, moved here
+# from printer.base.cfg only because the Pro needs to declare this pin as a
+# [heater_fan] instead and a pin may be claimed once. On this model there is no
+# element to cool and no chamber_heater to bind to, so it stays exactly what
+# FlashForge ships: a plain fan, off until something asks for it.
+#
+# Nothing in the mod drives it. It is absent from printer.macro.cfg's M106
+# P-map and from HelixScreen's fan list, so SET_FAN_SPEED FAN=chamber_heat_fan
+# is the only way to move it -- which is what the stock app did on this model
+# too. The general-purpose chamber fans are chamber_fan and chamber_loop_fan.
+[fan_generic chamber_heat_fan]
+pin:PD12
+hardware_pwm: False

--- a/pkgs/klipper-config/payload/config/chamber/Creator5Pro.cfg
+++ b/pkgs/klipper-config/payload/config/chamber/Creator5Pro.cfg
@@ -32,3 +32,66 @@ max_error: 100
 heating_gain: 0.1
 check_gain_time: 2400
 hysteresis: 5
+
+# ---------------------------------------------------------------------------
+# The heating element's fan (PD12), moved here from printer.base.cfg because
+# only this model can bind it: [heater_fan] resolves its heater at klippy:ready
+# and lookup_heater() raises on a machine that has no chamber_heater.
+#
+# firmwareExe did this in the touchscreen app, not on the printer. Its
+# CommMgr::heatManager case 5 fired SET_FAN_SPEED FAN=chamber_heat_fan
+# SPEED=0.9 immediately before every SET_HEATER_TEMPERATURE HEATER=
+# chamber_heater, and SPEED=0 before every TARGET=0 -- a single open-loop test
+# on "is the requested target non-zero", evaluated once, at the instant the
+# target was written. Nothing on the printer knew about the pairing. Set a
+# chamber target from a sliced M141, from Mainsail, or from Moonraker and the
+# element ran with its fan stopped, because the app was the only thing that
+# ever turned it on. This mod replaces that app, so the coupling has to live
+# somewhere that every client goes through.
+#
+# [heater_fan] IS that place, and it is strictly stronger than the app's
+# version. Its 1 Hz callback is
+#
+#     if target_temp or current_temp > self.heater_temp: speed = fan_speed
+#
+# so the fan follows the TARGET, not the heater pin. That matters here: PE13 is
+# a PID output on Klipper's default 0.1 s pwm_cycle_time, so it is a 10 Hz
+# waveform sitting at a fractional duty for most of a soak -- a fan slaved to
+# the pin would chop audibly and never reach speed. The target is the honest
+# signal for "the element may energise at any moment", and it is set before the
+# first pulse and cleared after the last.
+#
+# It also runs below G-code, which the app's version did not: a pause, a
+# cancel, a klippy exception or a client that dies mid-print cannot leave the
+# element hot with the fan off, and fan.Fan(default_shutdown_speed=1.) drives
+# PD12 to FULL on an MCU shutdown -- the case where a macro would already be
+# dead. There is no tach on PD12 (no chamber fan on this machine has one), so
+# nothing here or anywhere else can detect a stalled fan; what limits a stall
+# is max_power 0.8 on the element and [verify_heater], neither of which is
+# fan-aware. Do not read this section as stall protection.
+#
+# heater_temp is the one place the far-away thermistor is consulted, and only
+# ever to EXTEND the run, never to start it: the fan is already on for the
+# whole time a target is set, and this keeps it on afterwards while the chamber
+# is still hot. The sensor is PC1, in the chamber air rather than on the
+# element, so this is a coarse over-run and not an element measurement -- which
+# is the safe direction to be wrong in. 50 C is above what the bed alone drives
+# a closed chamber to, so a plain PLA print does not spin a 90 % fan for hours;
+# lower it for a longer purge, raise it toward max_temp to shorten one.
+#
+# The element does have its own thermistor -- [temperature_sensor ptcTemp] on
+# PC0 -- which would be the better over-run signal. It cannot be used without
+# giving it up as a sensor: a [temperature_fan] would have to claim PC0, and
+# pins.py raises "pin PC0 used multiple times in config" for a second claim, so
+# the reading would vanish from the UIs that display it.
+#
+# fan_speed 0.9 is the app's constant (0x3f666666 in heatManager). This fan is
+# now driven only from here: it is not in printer.macro.cfg's M106 P-map, and
+# SET_FAN_SPEED no longer reaches it, by design.
+# ---------------------------------------------------------------------------
+[heater_fan chamber_heat_fan]
+pin: PD12
+hardware_pwm: False
+heater: chamber_heater
+fan_speed: 0.9
+heater_temp: 50.0

--- a/pkgs/klipper-config/payload/config/ff-chamber.cfg
+++ b/pkgs/klipper-config/payload/config/ff-chamber.cfg
@@ -38,29 +38,79 @@ description: M141/M191 tunables
 # M191 stops waiting this far below the target. The chamber is a slow, lossy
 # volume; the app never waited on it tighter than a couple of degrees.
 variable_wait_band: 2.0
-# Never called: this holds the tunable above, nothing more. M141/M191 do the
+# Speed for chamber_loop_fan while a chamber target is set; 0 disables the
+# coupling entirely and leaves the fan to the user. See SET_HEATER_TEMPERATURE
+# below for why this fan is driven here and chamber_heat_fan is not.
+variable_loop_fan: 0.3
+# Never called: this holds the tunables above, nothing more. M141/M191 do the
 # model gating themselves.
 gcode:
 
-# SET_HEATER_TEMPERATURE -- stock command, chamber target gated by model.
-# Anything that is not a non-zero chamber target passes straight through, so
-# hotends, the bed and "chamber off" behave exactly as before. On a machine
-# with no heater the real command would fail with "Unknown heater", which is
-# right for a typed command but would abort a print on a sliced M141 -- so a
-# blocked call warns and continues. PID_CALIBRATE and anything else reaching
-# past these macros still fails, as it should.
+# SET_HEATER_TEMPERATURE -- stock command, chamber target gated by model, and
+# the one choke point every chamber target passes through.
+#
+# Anything that is not a chamber command passes straight through, so hotends
+# and the bed behave exactly as before. A chamber command on a model with no
+# chamber heater is swallowed instead: the base command is a mux keyed on
+# HEATER and would raise "The value 'chamber_heater' is not valid for HEATER",
+# which is right for a command someone typed but aborts a print when the line
+# came out of a slicer. PID_CALIBRATE and anything else reaching past these
+# macros still fails, as it should.
+#
+# It also carries the second half of the chamber fan coupling. firmwareExe ran
+# TWO fans with the element -- chamber_heat_fan at 0.9 and chamber_loop_fan at
+# 0.3, both fired from CommMgr::heatManager on a plain "target != 0" test --
+# and this mod replaces the binary that did it. chamber_heat_fan is now a
+# [heater_fan] in printer.chamber.cfg, which is the better home: it follows the
+# target without any G-code running, so a pause, a cancel or a klippy fault
+# cannot strand a hot element behind a stopped fan.
+#
+# chamber_loop_fan cannot go the same way. HelixScreen publishes it by object
+# name as the user's "aux" fan (settings.json: "aux": "fan_generic
+# chamber_loop_fan"), and a [heater_fan] is neither that object nor settable at
+# all, so converting it would take the aux slider away and break the name the
+# UI resolves. It stays a [fan_generic] and is driven from here instead --
+# which is exactly where the app drove it, and unlike the app this reaches
+# every client, not just the touchscreen.
+#
+# Like the app, this overwrites a manual aux setting: 0.3 while a target is
+# set, 0 when it is cleared. Set _FF_CHAMBER's loop_fan to 0 to keep the fan
+# entirely under the user's hand. The fan leads the heater on the way up and
+# trails it on the way down, so the chamber is never heating unventilated.
 [gcode_macro SET_HEATER_TEMPERATURE]
 description: Set a heater target (chamber ignored on models without the heater)
 rename_existing: SET_HEATER_TEMPERATURE_BASE
 gcode:
     {% set heater = params.HEATER|default('')|lower %}
     {% set target = params.TARGET|default(0)|float %}
-    {% if heater == 'chamber_heater' and target > 0
+    {% set ff = printer['gcode_macro _FF_CHAMBER'] %}
+    {% set is_chamber = heater == 'chamber_heater'
+                        and 'heater_generic chamber_heater' in printer %}
+    {% set loop = ff.loop_fan|float %}
+    {% if heater == 'chamber_heater'
           and 'heater_generic chamber_heater' not in printer %}
-        { action_respond_info(
-            "no chamber heater on this model -- ignoring TARGET=%.1f" % target) }
+        # Every chamber command is blocked here, not just a non-zero target.
+        # SET_HEATER_TEMPERATURE is a mux command keyed on HEATER, so on a
+        # model that never registered chamber_heater the base command raises
+        # "The value 'chamber_heater' is not valid for HEATER" -- a command
+        # error, which aborts the running print. TARGET=0 raises it exactly as
+        # TARGET=60 does, and slicers put M141 S0 in their end G-code, so
+        # gating only on target > 0 left the common case failing.
+        #
+        # Turning off a heater that does not exist is a no-op, so it passes in
+        # silence; only a real request being dropped is worth a message.
+        {% if target > 0 %}
+            { action_respond_info(
+                "no chamber heater on this model -- ignoring TARGET=%.1f" % target) }
+        {% endif %}
     {% else %}
+        {% if is_chamber and loop > 0 and target > 0 %}
+            SET_FAN_SPEED FAN=chamber_loop_fan SPEED={loop}
+        {% endif %}
         SET_HEATER_TEMPERATURE_BASE {rawparams}
+        {% if is_chamber and loop > 0 and target <= 0 %}
+            SET_FAN_SPEED FAN=chamber_loop_fan SPEED=0
+        {% endif %}
     {% endif %}
 
 # M141 [S<temp>] -- set chamber temperature, do not wait.

--- a/pkgs/klipper-config/payload/config/ff-filament.cfg
+++ b/pkgs/klipper-config/payload/config/ff-filament.cfg
@@ -79,8 +79,12 @@ variable_unload_feed: 600
 variable_purge_length: 50.0
 variable_purge_retract: 5.0
 variable_purge_fan: 0.6
-# Chamber fans around the feed (app: changeFilamentControlFan).
-variable_chamber_heat_fan: 0.9
+# Chamber fan around the feed (app: changeFilamentControlFan). The app also
+# blacked out chamber_heat_fan here and restored it to 0.9; that fan is now a
+# [heater_fan] tied to chamber_heater (see printer.chamber.cfg), so it is not
+# settable and is deliberately left running -- a filament change over a hot
+# element is the last moment to stop ventilating it. Only the draught that
+# reaches the purge chute is worth silencing, and that is chamber_fan and this.
 variable_chamber_loop_fan: 0.3
 # Pre-print nozzle clean (app: clearNozzlePrint, used by START_PRINT via
 # _FF_NOZZLE_CLEAN). After the purge the app parks at (266.5, 13.8), 1 mm
@@ -179,7 +183,6 @@ gcode:
     SET_FAN_SPEED FAN=chamber_fan SPEED=0
     {% if 'heater_generic chamber_heater' in printer
           and printer["heater_generic chamber_heater"].target > 0 %}
-        SET_FAN_SPEED FAN=chamber_heat_fan SPEED=0
         SET_FAN_SPEED FAN=chamber_loop_fan SPEED=0
     {% endif %}
 
@@ -196,7 +199,6 @@ gcode:
     SET_FAN_SPEED FAN=chamber_fan SPEED={ff.saved_chamber_fan}
     {% if 'heater_generic chamber_heater' in printer
           and printer["heater_generic chamber_heater"].target > 0 %}
-        SET_FAN_SPEED FAN=chamber_heat_fan SPEED={ff.chamber_heat_fan}
         SET_FAN_SPEED FAN=chamber_loop_fan SPEED={ff.chamber_loop_fan}
     {% endif %}
     {% if not ff.in_print %}

--- a/pkgs/klipper-config/payload/config/printer.base.cfg
+++ b/pkgs/klipper-config/payload/config/printer.base.cfg
@@ -137,12 +137,15 @@ hold_current: 1.1   # hold current
 interpolate: True   # enale step interpolate or not
 stall_threshold: 0.6
 
-# The chamber heater and its supervision moved to printer.chamber.cfg, which
-# differs by model. Klipper config can override an option but cannot
+# The chamber heater, its supervision and its fan moved to printer.chamber.cfg,
+# which differs by model. Klipper config can override an option but cannot
 # un-declare a section, so a heater that does not exist has to be absent from
-# the file rather than neutralised in it. Everything else here is FlashForge's
-# printer.base.cfg verbatim -- bin/unpack.sh compares it against each stock
-# package it opens and warns if FlashForge's file has changed.
+# the file rather than neutralised in it. chamber_heat_fan follows for the same
+# reason: on the Pro it is a [heater_fan] bound to chamber_heater, which is a
+# different section type on a pin that may be claimed only once. Everything
+# else here is FlashForge's printer.base.cfg verbatim -- bin/unpack.sh compares
+# it against each stock package it opens and warns if FlashForge's file has
+# changed.
 [include printer.chamber.cfg]
 
 [stepper_enable]
@@ -200,10 +203,6 @@ heater:extruder,extruder1,extruder2,extruder3
 [fan_generic chamber_fan]
 pin:PE11
 hardware_pwm:False
-
-[fan_generic chamber_heat_fan]
-pin:PD12
-hardware_pwm: False 
 
 [fan_generic chamber_loop_fan]
 pin:PB10

--- a/qa/static/test_klipper_config.py
+++ b/qa/static/test_klipper_config.py
@@ -1,0 +1,331 @@
+"""The Klipper config we ship: one pin, one owner, and macros that compile.
+
+THE BUG THIS EXISTS FOR. `chamber_heat_fan` had to change section type per
+model -- `[heater_fan]` on the Pro so the element's fan follows the chamber
+heater without any G-code running, `[fan_generic]` on the plain Creator 5,
+which has no `chamber_heater` for `lookup_heater()` to resolve at
+`klippy:ready`. Klipper can override an option but cannot un-declare a section,
+so the section had to MOVE out of `printer.base.cfg` into the per-model
+`chamber/<model>.cfg`.
+
+That move is the dangerous kind. Leave the old section behind and PD12 is
+claimed twice; `pins.py` raises "pin PD12 used multiple times in config" and
+klippy refuses to start -- on a printer, after a flash, with no UI to say why.
+Nothing else in the suite reads these files: `test_ipk.py` checks that the
+chamber configs are PACKAGED, never that they PARSE.
+
+WHY THIS LANE, AND WHAT IT THEREFORE CANNOT SEE. The static lane runs on a bare
+checkout, so the only configs here are the ones this repo ships. FlashForge's
+own includes -- printer.filament.cfg, printer.probe.cfg, printer.mesh.cfg,
+printer.vibration.cfg -- exist only under work/ after `bin/unpack.sh`, and
+conftest is explicit that a missing firmware image is a failure rather than a
+skip, so depending on them here would make this lane fail on a clean clone.
+They are skipped, and a pin they claim that one of ours also claims is NOT
+caught here. That is a real hole; what closes it is that every pin-bearing
+section on the main MCU lives in printer.base.cfg, which is ours.
+
+WHY RawConfigParser(strict=False). Klipper's own parser. Same-named sections
+MERGE and the last value wins, which is the mechanism ff-chamber.cfg uses to
+override `initial_WHITE` on `[led chamber_led]`; a strict parser would call
+that a duplicate-section error and this test would be wrong about the file the
+printer actually reads.
+"""
+import ast
+import configparser
+import re
+import shlex
+
+import jinja2
+import pytest
+
+from lib.paths import ROOT
+
+pytestmark = pytest.mark.static
+
+CONFIG = ROOT / "pkgs" / "klipper-config" / "payload" / "config"
+MODELS = ("Creator5", "Creator5Pro")
+# Only the Pro has a chamber heating element, which is the single functional
+# difference between the two stock firmwareExe builds.
+HAS_HEATER = {"Creator5": False, "Creator5Pro": True}
+
+# Outputs and thermistors. `endstop_pin` is deliberately absent: Klipper shares
+# endstops by design (share_type "endstop"), and FlashForge's hd_home and
+# e_stop extras re-claim those same input pins on purpose. An output pin or an
+# ADC pin cannot be claimed twice under any share_type, so those are the ones
+# worth asserting on.
+PIN_OPTS = ("pin", "heater_pin", "sensor_pin", "white_pin", "red_pin",
+            "green_pin", "blue_pin", "step_pin", "dir_pin", "enable_pin")
+SHARED_SECTION_TYPES = ("hd_home", "e_stop", "gcode_button")
+
+INCLUDE = re.compile(r"^\[include (.+)\]\s*$")
+
+
+def _resolve(name, model):
+    # printer.chamber.cfg is not a file in the payload: the package ships a
+    # chamber/ directory and anvil-link-prog.sh links the model's file into
+    # place on the printer. Resolve it the same way.
+    if name == "printer.chamber.cfg":
+        return CONFIG / "chamber" / (model + ".cfg")
+    path = CONFIG / name
+    return path if path.is_file() else None
+
+
+def _assemble(model):
+    """The config text klippy would see, minus FlashForge's own includes."""
+    seen, chunks, skipped = set(), [], []
+
+    def load(name):
+        path = _resolve(name, model)
+        if path is None:
+            skipped.append(name)
+            return
+        if path in seen:
+            return
+        seen.add(path)
+        body = []
+        for line in path.read_text(encoding="utf-8").splitlines():
+            m = INCLUDE.match(line)
+            if m:
+                load(m.group(1).strip())
+                body.append("")
+            else:
+                body.append(line)
+        chunks.append("\n".join(body))
+
+    load("printer.base.cfg")
+    return "\n".join(chunks), skipped
+
+
+def _parse(model):
+    text, _ = _assemble(model)
+    # klippy's own parser settings (configfile.py). inline_comment_prefixes
+    # matters as much as strict=False: configparser strips ';' and '#' only
+    # when whitespace precedes them, so a ';' inside a string literal -- as in
+    # ff-filament's "paused with T%s mounted; filament operations ..." --
+    # survives. Stripping comments by hand instead reports those as broken.
+    cp = configparser.RawConfigParser(
+        strict=False, inline_comment_prefixes=(";", "#"))
+    cp.read_string(text)
+    return cp
+
+
+# --------------------------------------------------------------------------
+# Running the macros, because parsing them is not the same as believing them.
+#
+# THE BUG THIS HALF EXISTS FOR. SET_HEATER_TEMPERATURE is a MUX command keyed
+# on HEATER: klippy dispatches it through _cmd_mux, which raises "The value
+# 'chamber_heater' is not valid for HEATER" for a heater that was never
+# registered (gcode.py). That is a command error, and a command error aborts a
+# running print. On the plain Creator 5 there is no chamber_heater, and the
+# gate in ff-chamber.cfg only blocked TARGET > 0 -- so `M141 S0`, which is what
+# slicers put in their END G-CODE, went straight to the base command and killed
+# the print at the very end. The file's own header said "chamber off behaves
+# exactly as before"; it did not.
+#
+# Reading the macro did not show that. Running it did.
+# --------------------------------------------------------------------------
+
+ARGS_R = re.compile("([A-Z_]+|[A-Z*])")
+
+
+def _is_traditional(cmd):
+    return len(cmd) >= 2 and cmd[0].isupper() and cmd[1].isdigit()
+
+
+def _parse_params(line, cmd):
+    """klippy's TWO parameter parsers, which disagree with each other.
+
+    Traditional (M141): args_r.split(line.upper()) -- the whole line is
+    uppercased, and "M141 S60" yields {'M': '141', 'S': '60'}.
+
+    Extended (SET_HEATER_TEMPERATURE): shlex over the RAW text, keys uppercased
+    and values left alone, which is why HEATER=chamber_heater stays lowercase
+    and the macro's `|lower` is load-bearing rather than decorative.
+    """
+    rest = line[len(line.split()[0]):]
+    if _is_traditional(cmd):
+        parts = ARGS_R.split(line.upper())
+        return {parts[i]: parts[i + 1].strip()
+                for i in range(1, len(parts) - 1, 2)}
+    lex = shlex.shlex(rest, posix=True)
+    lex.whitespace_split = True
+    lex.commenters = "#;"
+    return {k.upper(): v for k, v in (a.split("=", 1) for a in lex)}
+
+
+def _run(model, command, has_heater):
+    """Expand `command` until only non-macro commands remain, as klippy would.
+
+    Returns (emitted commands, action_respond_info messages).
+    """
+    cp = _parse(model)
+    printer = {}
+    for sec in cp.sections():
+        if sec.startswith("gcode_macro "):
+            variables = {}
+            for opt in cp.options(sec):
+                if opt.startswith("variable_"):
+                    try:
+                        variables[opt[9:]] = ast.literal_eval(cp.get(sec, opt))
+                    except (ValueError, SyntaxError):
+                        variables[opt[9:]] = cp.get(sec, opt)
+            printer[sec] = variables
+    if has_heater:
+        printer["heater_generic chamber_heater"] = {
+            "temperature": 25.0, "target": 0.0}
+
+    env = jinja2.Environment("{%", "%}", "{", "}")
+    out, info = [], []
+
+    def step(line, depth=0):
+        assert depth < 10, "macro recursion in %s" % command
+        line = line.strip()
+        if not line:
+            return
+        cmd = line.split()[0].upper()
+        sec = next((s for s in cp.sections()
+                    if s.lower() == ("gcode_macro " + cmd).lower()), None)
+        if sec is None or not cp.has_option(sec, "gcode"):
+            out.append(line)
+            return
+        rendered = env.from_string(cp.get(sec, "gcode")).render(
+            params=_parse_params(line, cmd),
+            rawparams=line[len(line.split()[0]):].strip(),
+            printer=printer,
+            action_respond_info=lambda m: info.append(m) or "",
+            action_raise_error=_raise,
+        )
+        for sub in rendered.splitlines():
+            step(sub, depth + 1)
+
+    step(command)
+    return out, info
+
+
+def _raise(msg):
+    raise AssertionError("macro raised: %s" % msg)
+
+
+def test_setting_a_chamber_target_starts_the_loop_fan_first():
+    out, _ = _run("Creator5Pro", "M141 S60", has_heater=True)
+    assert out == [
+        "SET_FAN_SPEED FAN=chamber_loop_fan SPEED=0.3",
+        "SET_HEATER_TEMPERATURE_BASE HEATER=chamber_heater TARGET=60.0",
+    ], out
+
+
+def test_clearing_a_chamber_target_stops_the_loop_fan_last():
+    out, _ = _run("Creator5Pro", "M141 S0", has_heater=True)
+    assert out == [
+        "SET_HEATER_TEMPERATURE_BASE HEATER=chamber_heater TARGET=0.0",
+        "SET_FAN_SPEED FAN=chamber_loop_fan SPEED=0",
+    ], out
+
+
+def test_m191_waits_below_the_target_by_the_band():
+    out, _ = _run("Creator5Pro", "M191 S60", has_heater=True)
+    assert 'TEMPERATURE_WAIT SENSOR="heater_generic chamber_heater" ' \
+           "MINIMUM=58.0" in out, out
+
+
+@pytest.mark.parametrize("command", ["M141 S0", "M191 S0", "M141"])
+def test_turning_the_chamber_off_is_silent_on_a_model_without_one(command):
+    """The end-of-print case. Emitting anything here aborts the print."""
+    out, info = _run("Creator5", command, has_heater=False)
+    assert out == [], (
+        "%s reaches klippy on a Creator 5 and SET_HEATER_TEMPERATURE is a mux "
+        "command: it raises \"The value 'chamber_heater' is not valid for "
+        "HEATER\" and aborts the print. Emitted: %s" % (command, out))
+    assert info == [], "nothing to turn off is not worth a message: %s" % info
+
+
+def test_asking_for_chamber_heat_on_a_model_without_one_warns_and_continues():
+    out, info = _run("Creator5", "M141 S60", has_heater=False)
+    assert out == [], out
+    assert info and "ignoring TARGET=60.0" in info[0], info
+
+
+@pytest.mark.parametrize("model", MODELS)
+def test_other_heaters_are_untouched(model):
+    """The gate must not cost the hotend or the bed anything."""
+    out, info = _run(model, "SET_HEATER_TEMPERATURE HEATER=extruder TARGET=220",
+                     HAS_HEATER[model])
+    assert out == ["SET_HEATER_TEMPERATURE_BASE HEATER=extruder TARGET=220"], out
+    assert info == []
+
+
+@pytest.mark.parametrize("model", MODELS)
+def test_the_shipped_config_parses(model):
+    cp = _parse(model)
+    assert cp.sections(), "%s assembled to nothing -- includes did not resolve" % model
+
+
+@pytest.mark.parametrize("model", MODELS)
+def test_no_output_pin_is_claimed_twice(model):
+    cp = _parse(model)
+    claims = {}
+    for sec in cp.sections():
+        if sec.split()[0] in SHARED_SECTION_TYPES:
+            continue
+        for opt in PIN_OPTS:
+            if not cp.has_option(sec, opt):
+                continue
+            raw = cp.get(sec, opt).split(",")[0].strip()
+            pin = raw.lstrip("!^~").strip()
+            # A templated or empty value is not a literal claim.
+            if not pin or "{" in pin:
+                continue
+            claims.setdefault(pin, []).append("[%s] %s" % (sec, opt))
+
+    dupes = {p: v for p, v in sorted(claims.items()) if len(v) > 1}
+    assert not dupes, "klippy would refuse to start on %s:\n%s" % (
+        model,
+        "\n".join("  pin %s claimed by %s" % (p, " AND ".join(v))
+                  for p, v in dupes.items()),
+    )
+
+
+@pytest.mark.parametrize("model", MODELS)
+def test_every_gcode_macro_body_compiles(model):
+    # Klipper's own delimiters (gcode_macro.py: Environment('{%','%}','{','}')).
+    # A default Environment would read `{rawparams}` as literal text and compile
+    # anything, which is a test that cannot fail.
+    env = jinja2.Environment("{%", "%}", "{", "}")
+    cp = _parse(model)
+    broken = []
+    for sec in cp.sections():
+        if not sec.startswith("gcode_macro ") or not cp.has_option(sec, "gcode"):
+            continue
+        # No hand-stripping: _parse() already read this with klippy's own
+        # inline_comment_prefixes, so the body here is the body Jinja gets.
+        src = cp.get(sec, "gcode")
+        try:
+            env.from_string(src)
+        except jinja2.TemplateSyntaxError as exc:
+            broken.append("  [%s] line %s: %s" % (sec, exc.lineno, exc.message))
+    assert not broken, "macros klippy would reject on %s:\n%s" % (
+        model, "\n".join(broken))
+
+
+@pytest.mark.parametrize("model", MODELS)
+def test_the_chamber_heater_fan_matches_the_model(model):
+    """The point of the move: the Pro binds the fan to the heater, the plain
+    Creator 5 cannot, and neither may leave the section in printer.base.cfg."""
+    cp = _parse(model)
+    base = (CONFIG / "printer.base.cfg").read_text(encoding="utf-8")
+    assert not re.search(r"^\[\w+ chamber_heat_fan\]", base, re.M), (
+        "chamber_heat_fan must live in chamber/<model>.cfg, not printer.base.cfg: "
+        "a section left in both claims PD12 twice")
+
+    if model == "Creator5Pro":
+        sec = "heater_fan chamber_heat_fan"
+        assert sec in cp.sections(), "the Pro's element fan must follow the heater"
+        assert cp.get(sec, "heater").strip() == "chamber_heater"
+        assert cp.get(sec, "pin").strip() == "PD12"
+    else:
+        sec = "fan_generic chamber_heat_fan"
+        assert sec in cp.sections(), (
+            "the plain Creator 5 has no chamber_heater, so a [heater_fan] here "
+            "would fail lookup_heater() at klippy:ready")
+        assert cp.get(sec, "pin").strip() == "PD12"
+        assert "heater_fan chamber_heat_fan" not in cp.sections()


### PR DESCRIPTION
## What this is

`firmwareExe` was the only thing on the machine that knew the chamber heating element needed air. `CommMgr::heatManager` case 5 fired `SET_FAN_SPEED FAN=chamber_heat_fan SPEED=0.9` and `chamber_loop_fan SPEED=0.3` immediately before every `SET_HEATER_TEMPERATURE HEATER=chamber_heater`, on a bare `target != 0` test evaluated once, at the instant the target was written — no state machine, no delay, no run-on, and on the way down it stopped the fans a moment *before* dropping the target.

Nothing on the printer knew about that pairing. Set a chamber target from a sliced `M141`, from Mainsail or from Moonraker and the element ran with its fans stopped. This mod replaces that binary and adds M141/M191, so the coupling had to move somewhere every client passes through.

## The approach

`chamber_heat_fan` becomes a `[heater_fan]` bound to `chamber_heater`. It follows the **target**, not the heater pin — PE13 is a PID output on Klipper's default 0.1 s `pwm_cycle_time`, so a fan slaved to the pin would chop at 10 Hz and never reach speed. It runs below G-code, so a pause, a cancel or a klippy fault cannot strand a hot element behind a stopped fan, and `fan.Fan(default_shutdown_speed=1.)` drives PD12 to full on an MCU shutdown — the one case where a macro is already dead.

Two constraints from the hardware, handled explicitly:

- **The chamber thermistor is far from the element.** So it never gates the *start*: `target_temp` does. Temperature is consulted only via `heater_temp: 50`, and only to *extend* the run after the target clears — a coarse over-run, wrong in the safe direction. (The element does have its own thermistor, `ptcTemp` on PC0, which would be the better over-run signal — but a `[temperature_fan]` would have to claim PC0 and `pins.py` raises "used multiple times" on a second claim, so the reading would vanish from the UIs. Documented in the config rather than taken.)
- **No RPM feedback.** `heater_fan` needs none. But nothing here detects a stalled fan and it does not claim to; the limits remain `max_power: 0.8` and `verify_heater`, neither of which is fan-aware.

The section had to **move** out of `printer.base.cfg`: `[heater_fan]` resolves its heater at `klippy:ready` and `lookup_heater()` raises on the plain Creator 5, and a pin may be claimed only once. The plain model keeps FlashForge's `[fan_generic]`; the Pro declares the `[heater_fan]` — in the per-model `chamber/<model>.cfg` that already exists for the heater itself.

`chamber_loop_fan` deliberately does **not** go the same way: HelixScreen publishes it by object name as the user's aux fan (`"aux": "fan_generic chamber_loop_fan"`), and a `[heater_fan]` is neither that object nor settable, so converting it would take the aux slider away. It stays a `[fan_generic]` driven from the `SET_HEATER_TEMPERATURE` wrapper — where the app drove it, except this reaches every client rather than only the touchscreen.

## Separately, a bug this found

`SET_HEATER_TEMPERATURE` is a **mux command** keyed on `HEATER`. `_cmd_mux` raises `The value 'chamber_heater' is not valid for HEATER` for a heater that was never registered, and a command error aborts a running print.

The gate in `ff-chamber.cfg` only blocked `TARGET > 0`, so `TARGET=0` went straight to the base command and threw — and `M141 S0` is what slicers put in their **end G-code**. On a plain Creator 5, a chamber-aware profile ran the whole print and died at the last line. The file's own header claimed "chamber off behaves exactly as before"; it did not.

## Also fixed: the drift guard was already broken

`bin/unpack.sh`'s `strip()` dropped the moved sections' *header* lines but left their option lines on the stock side with nothing to match, and did not know about `[include timelapse.cfg]`. It printed `printer.base.cfg DIFFERS` on **every** unpack and had been silently useless. Fixed here because this change would otherwise have deepened it.

## Tests

`qa/static/test_klipper_config.py` is new — there was no config coverage at all, and `test_ipk` checks that the chamber configs are *packaged*, never that they *parse*.

It asserts pin uniqueness and that every macro compiles, and it **executes** M141/M191 on both models — the half that earned its place, because reading the macro did not show the mux bug and running it did. It reproduces klippy's real parsers rather than approximating them:

- `Environment('{%','%}','{','}')` — single-brace delimiters, so `{rawparams}` is a template and not literal text
- `RawConfigParser(inline_comment_prefixes=(';','#'))` — a `;` inside a string literal survives, as configparser leaves it
- both of `gcode.py`'s disagreeing parameter parsers: traditional `args_r.split(line.upper())` for `M141`, shlex with keys-only uppercasing for the extended form — which is what makes the macro's `|lower` load-bearing

Both fixes were mutation-tested: re-adding the duplicate section, and restoring the `target > 0` gate, each fail the tests written for them.

| | Creator 5 Pro | Creator 5 |
|---|---|---|
| `M141 S60` | loop fan 0.3 → `TARGET=60.0` | warns, emits nothing |
| `M141 S0` | `TARGET=0.0` → loop fan 0 | silent, emits nothing |
| `M191 S60` | fan → target → `TEMPERATURE_WAIT … MINIMUM=58.0` | warns, emits nothing |
| `HEATER=extruder TARGET=220` | passes through | passes through |

## Status

- `make qa-static` — **171 passed, 3 skipped** in the container, including the ipk packaging tests and shellcheck
- `make packages PKG=klipper-config` builds clean; packaged tree verified — `heater_fan` on the Pro, `fan_generic` on the plain model, `printer.base.cfg` declaring `chamber_heat_fan` zero times

**`make qa-replica` has NOT been run.** The worktree it was built in has no `work/` tree, so the lane needs a full `make build`. Nothing has yet had the real klippy load this config, which is the check that matters most here — the failure mode is a printer that will not boot klippy after a flash. **Please let the replica lane run before merging.**

`heater_temp: 50` and the 0.9 fan speed also still want one real chamber heat-up; no test settles those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDJmG2hGGqNEYwc6Hj5P12
