### PR TITLE
XYZ calibration homes itself instead of refusing

### DIFF
--- a/docs/calibration.md
+++ b/docs/calibration.md
@@ -100,7 +100,6 @@ nozzle descends. A failed run leaves the previous calibration intact.
 
 | Message | What happened |
 |---|---|
-| `home all axes first (homed: '')` | Only with `HOME=0`: both commands home themselves otherwise. Run `G28`, or drop `HOME=0`. |
 | `G28 left the axes unhomed (homed: '<axes>')` | Homing was auto-started and did not finish — an endstop or the toolchanger refused. Fix that first; nothing was measured. |
 | `no tool is mounted. SELECT_TOOL T=<0..3> first` | You ran the tool pass with an empty carriage. It would have measured the bare carriage and saved it as a nozzle — ~3.2 mm out, in the direction that crashes. `TOOL_LOCATE_SENSOR` is the one that wants an empty carriage. |
 | `carriage is not verifiably empty (<reason>) -- the station pass must run with no tool mounted` | `TOOL_LOCATE_SENSOR` with a tool still on, or the dock and grab sensors disagree. `<reason>` names which. |

--- a/docs/calibration.md
+++ b/docs/calibration.md
@@ -26,8 +26,7 @@ and how those numbers reach a first layer, is
 ## The sequence
 
 ```gcode
-G28                      ; all three axes
-CALIBRATE_TOOL_OFFSETS   ; the whole thing
+CALIBRATE_TOOL_OFFSETS   ; the whole thing -- homes first if it has to
 SAVE_CONFIG              ; persists it, restarts Klipper
 ```
 
@@ -45,7 +44,6 @@ TOOL_LOCATE_SENSOR                ; the reference, empty carriage
 Run those by hand instead when you only want one tool:
 
 ```gcode
-G28
 TOOL_LOCATE_SENSOR       ; only if the station or bed was disturbed
 SELECT_TOOL T=2
 TOOL_CALIBRATE_TOOL_OFFSET
@@ -102,7 +100,8 @@ nozzle descends. A failed run leaves the previous calibration intact.
 
 | Message | What happened |
 |---|---|
-| `home all axes first (homed: '')` | Run `G28`. |
+| `home all axes first (homed: '')` | Only with `HOME=0`: both commands home themselves otherwise. Run `G28`, or drop `HOME=0`. |
+| `G28 left the axes unhomed (homed: '<axes>')` | Homing was auto-started and did not finish — an endstop or the toolchanger refused. Fix that first; nothing was measured. |
 | `no tool is mounted. SELECT_TOOL T=<0..3> first` | You ran the tool pass with an empty carriage. It would have measured the bare carriage and saved it as a nozzle — ~3.2 mm out, in the direction that crashes. `TOOL_LOCATE_SENSOR` is the one that wants an empty carriage. |
 | `carriage is not verifiably empty (<reason>) -- the station pass must run with no tool mounted` | `TOOL_LOCATE_SENSOR` with a tool still on, or the dock and grab sensors disagree. `<reason>` names which. |
 | `[ff_toolchange] not loaded` | Config problem, not an operator one: `ff-toolchange.cfg` is not included. |

--- a/docs/how-calibration-works.md
+++ b/docs/how-calibration-works.md
@@ -86,9 +86,9 @@ difference between a first layer that sticks and one that does not.
 
 #### `TOOL_LOCATE_SENSOR` — the reference
 
-`[PARK=1] [SAVE=1]`
+`[SAVE=1]`
 
-1. Parks the mounted tool (`PARK=0` if you docked it by hand) and verifies
+1. Homes if any axis is unhomed, parks the mounted tool, and verifies
    the carriage really is empty, from the dock and grab sensors.
 2. Plate check: probes station Z with the bare carriage, then sideways for
    the bore edge.
@@ -107,8 +107,9 @@ carriage** — select the tool first.
 
 `[SAVE=1]`
 
-1. Plate check. It needs an empty carriage, so it parks your tool and picks
-   it straight back up — that is expected, not a fault.
+1. Homes if any axis is unhomed, then the plate check. Both need an empty
+   carriage, so your tool is parked and picked straight back up — that is
+   expected, not a fault.
 2. Zeroes the G-code offset and works in raw machine coordinates.
 3. Same two passes as above, from `cylinder_x − 12.5` (16.0 stock), with the
    nozzle doing the touching.

--- a/pkgs/klipper-config/payload/config/ff-tool-offset.cfg
+++ b/pkgs/klipper-config/payload/config/ff-tool-offset.cfg
@@ -39,9 +39,8 @@
 # Prerequisites: [ff_tool 0..3] and [ff_toolchange]; the PEI sheet removed.
 # Both commands run G28 themselves when an axis is unhomed -- every move they
 # make is in absolute machine coordinates, so an unhomed axis is a crash, not
-# a warning. HOME=0 refuses instead of homing. Do not write nozzle_*/station_*
-# in an include -- SAVE_CONFIG refuses to autosave an option an include
-# already sets.
+# a warning. Do not write nozzle_*/station_* in an include -- SAVE_CONFIG
+# refuses to autosave an option an include already sets.
 #
 # Safety notes, all divergences from the app, which accepts ANY numbers:
 #   * homing docks a mounted tool (Z homes on the carriage's eddy sensor), so

--- a/pkgs/klipper-config/payload/config/ff-tool-offset.cfg
+++ b/pkgs/klipper-config/payload/config/ff-tool-offset.cfg
@@ -36,11 +36,17 @@
 # absolute station-frame, so calibrating only T2 leaves T0/T1/T3 valid.
 # firmwareExe's extruder.json is never read or written.
 #
-# Prerequisites: [ff_tool 0..3] and [ff_toolchange]; all axes homed; the PEI
-# sheet removed. Do not write nozzle_*/station_* in an include -- SAVE_CONFIG
-# refuses to autosave an option an include already sets.
+# Prerequisites: [ff_tool 0..3] and [ff_toolchange]; the PEI sheet removed.
+# Both commands run G28 themselves when an axis is unhomed -- every move they
+# make is in absolute machine coordinates, so an unhomed axis is a crash, not
+# a warning. HOME=0 refuses instead of homing. Do not write nozzle_*/station_*
+# in an include -- SAVE_CONFIG refuses to autosave an option an include
+# already sets.
 #
 # Safety notes, all divergences from the app, which accepts ANY numbers:
+#   * homing docks a mounted tool (Z homes on the carriage's eddy sensor), so
+#     the tool pass picks its tool back up and refuses to measure if it
+#     cannot.
 #   * the plate check runs first on both commands and REFUSES if the build
 #     plate is still on -- a measurement, not an operator's promise.
 #   * z_target defaults to -3, not the app's -5: 2 mm less crash depth.

--- a/pkgs/klipper/payload/klipper/klippy/extras/ff_tool_offset.py
+++ b/pkgs/klipper/payload/klipper/klippy/extras/ff_tool_offset.py
@@ -317,14 +317,10 @@ class FFToolOffset:
         axis is not a warning, it is a crash. Homing it here is what the
         operator would type next anyway: G28 is the fork's wrapper, which
         docks a mounted tool before it homes Z, and the callers put the
-        tool back on the carriage afterwards. HOME=0 keeps the old
-        refusal for anyone driving the axes by hand."""
+        tool back on the carriage afterwards."""
         homed = self._homed_axes()
         if all(axis in homed for axis in 'xyz'):
             return
-        if not gcmd.get_int('HOME', 1, minval=0, maxval=1):
-            raise gcmd.error("%s: home all axes first (homed: '%s')"
-                             % (self.name, homed))
         gcmd.respond_info("%s: homing first (homed: '%s')"
                           % (self.name, homed))
         self._run('G28')
@@ -689,7 +685,7 @@ class FFToolOffset:
 
     cmd_TOOL_CALIBRATE_TOOL_OFFSET_help = (
         "Measure the MOUNTED tool's nozzle position against the station "
-        "([SAVE=1] [HOME=1] [PLATE_CHECK=1] [SAMPLES=] [SAMPLES_TOLERANCE=]"
+        "([SAVE=1] [PLATE_CHECK=1] [SAMPLES=] [SAMPLES_TOLERANCE=]"
         " [SAMPLES_TOLERANCE_RETRIES=] [SAMPLES_RESULT=]"
         " [SAMPLE_RETRACT_DIST=] [PROBE_SPEED=])")
 
@@ -789,8 +785,7 @@ class FFToolOffset:
 
     cmd_TOOL_LOCATE_SENSOR_help = (
         "Locate the station with an EMPTY carriage (station_x/y/z) "
-        "([PARK=1] [SAVE=1] [HOME=1] [PLATE_CHECK=1] [SAMPLES=]"
-        " [SAMPLES_TOLERANCE=]"
+        "([PARK=1] [SAVE=1] [PLATE_CHECK=1] [SAMPLES=] [SAMPLES_TOLERANCE=]"
         " [SAMPLES_TOLERANCE_RETRIES=] [SAMPLES_RESULT=]"
         " [SAMPLE_RETRACT_DIST=] [PROBE_SPEED=])")
 

--- a/pkgs/klipper/payload/klipper/klippy/extras/ff_tool_offset.py
+++ b/pkgs/klipper/payload/klipper/klippy/extras/ff_tool_offset.py
@@ -785,20 +785,18 @@ class FFToolOffset:
 
     cmd_TOOL_LOCATE_SENSOR_help = (
         "Locate the station with an EMPTY carriage (station_x/y/z) "
-        "([PARK=1] [SAVE=1] [PLATE_CHECK=1] [SAMPLES=] [SAMPLES_TOLERANCE=]"
+        "([SAVE=1] [PLATE_CHECK=1] [SAMPLES=] [SAMPLES_TOLERANCE=]"
         " [SAMPLES_TOLERANCE_RETRIES=] [SAMPLES_RESULT=]"
         " [SAMPLE_RETRACT_DIST=] [PROBE_SPEED=])")
 
     def cmd_TOOL_LOCATE_SENSOR(self, gcmd):
-        park = gcmd.get_int('PARK', 1, minval=0, maxval=1)
         save = gcmd.get_int('SAVE', 1, minval=0, maxval=1)
         try:
             self._check_homed(gcmd)
             if self.toolchange is not None:
-                if park:
-                    # releaseFourExtruder: the carriage must be empty for TS.
-                    self._run('TOOLCHANGE_PARK')
-                    self._wait_moves()
+                # releaseFourExtruder: the carriage must be empty for TS.
+                self._run('TOOLCHANGE_PARK')
+                self._wait_moves()
                 carriage = self.toolchange.get_status(self.reactor.monotonic())
                 if carriage.get('current_tool', -1) != -1 \
                    or not carriage.get('state_ok'):
@@ -806,10 +804,10 @@ class FFToolOffset:
                         "%s: carriage is not verifiably empty (%s) -- the"
                         " station pass must run with no tool mounted"
                         % (self.name, carriage.get('state_reason')))
-            elif park:
-                raise gcmd.error("%s: [ff_toolchange] not loaded -- park"
-                                 " the tool by hand and pass PARK=0."
-                                 % self.name)
+            # With no [ff_toolchange] there is no TOOLCHANGE_PARK to call and
+            # no sensor that can confirm the carriage is empty. Emptying it is
+            # the operator's job then, as it is on any printer without a
+            # toolchanger.
             self._run_plate_check(gcmd)
             cylinder_x, cylinder_y = self._cylinder()
             gcmd.respond_info("station calibration, start %.3f, %.3f"

--- a/pkgs/klipper/payload/klipper/klippy/extras/ff_tool_offset.py
+++ b/pkgs/klipper/payload/klipper/klippy/extras/ff_tool_offset.py
@@ -306,11 +306,32 @@ class FFToolOffset:
             y = CYLINDER_Y_DEFAULT
         return x, y
 
-    def _check_homed(self, gcmd):
+    def _homed_axes(self):
         toolhead = self.printer.lookup_object('toolhead')
-        homed = toolhead.get_status(self.reactor.monotonic())['homed_axes']
-        if not all(axis in homed for axis in 'xyz'):
+        return toolhead.get_status(self.reactor.monotonic())['homed_axes']
+
+    def _check_homed(self, gcmd):
+        """Home what is not homed, then insist on it.
+
+        Every move below is absolute machine coordinates, so an unhomed
+        axis is not a warning, it is a crash. Homing it here is what the
+        operator would type next anyway: G28 is the fork's wrapper, which
+        docks a mounted tool before it homes Z, and the callers put the
+        tool back on the carriage afterwards. HOME=0 keeps the old
+        refusal for anyone driving the axes by hand."""
+        homed = self._homed_axes()
+        if all(axis in homed for axis in 'xyz'):
+            return
+        if not gcmd.get_int('HOME', 1, minval=0, maxval=1):
             raise gcmd.error("%s: home all axes first (homed: '%s')"
+                             % (self.name, homed))
+        gcmd.respond_info("%s: homing first (homed: '%s')"
+                          % (self.name, homed))
+        self._run('G28')
+        self._wait_moves()
+        homed = self._homed_axes()
+        if not all(axis in homed for axis in 'xyz'):
+            raise gcmd.error("%s: G28 left the axes unhomed (homed: '%s')"
                              % (self.name, homed))
 
     def _current_accel(self):
@@ -548,8 +569,8 @@ class FFToolOffset:
         """Park whatever is mounted, then _plate_check. Shared prologue of
         both calibration commands; PLATE_CHECK=0 on the command skips it.
 
-        Returns True when the check ran -- the carriage is then empty, and
-        TOOL_CALIBRATE_TOOL_OFFSET has to pick its tool back up."""
+        Returns True when the check ran -- the carriage is then empty, so
+        TOOL_CALIBRATE_TOOL_OFFSET picks its tool back up afterwards."""
         if not gcmd.get_int('PLATE_CHECK', 1 if self.plate_check else 0,
                             minval=0, maxval=1):
             return False
@@ -668,7 +689,7 @@ class FFToolOffset:
 
     cmd_TOOL_CALIBRATE_TOOL_OFFSET_help = (
         "Measure the MOUNTED tool's nozzle position against the station "
-        "([SAVE=1] [PLATE_CHECK=1] [SAMPLES=] [SAMPLES_TOLERANCE=]"
+        "([SAVE=1] [HOME=1] [PLATE_CHECK=1] [SAMPLES=] [SAMPLES_TOLERANCE=]"
         " [SAMPLES_TOLERANCE_RETRIES=] [SAMPLES_RESULT=]"
         " [SAMPLE_RETRACT_DIST=] [PROBE_SPEED=])")
 
@@ -692,11 +713,23 @@ class FFToolOffset:
         save = gcmd.get_int('SAVE', 1, minval=0, maxval=1)
         try:
             self._check_homed(gcmd)
-            # The plate check has to measure an EMPTY carriage, so it parks the
-            # tool we were asked about. Pick it straight back up.
-            if self._run_plate_check(gcmd):
+            self._run_plate_check(gcmd)
+            # Both the plate check (it has to measure an EMPTY carriage) and
+            # homing (Z homes on the carriage's eddy sensor, so G28 docks
+            # first) leave the tool we were asked about in its dock. Pick it
+            # straight back up -- measuring a bare carriage would save a
+            # nozzle position ~3.2 mm out in the crash direction.
+            carriage = self.toolchange.get_status(self.reactor.monotonic())
+            if carriage.get('current_tool', -1) != tool:
                 self._run('T%d' % tool)
                 self._wait_moves()
+                carriage = self.toolchange.get_status(self.reactor.monotonic())
+                if carriage.get('current_tool', -1) != tool \
+                   or not carriage.get('state_ok'):
+                    raise gcmd.error(
+                        "%s: T%d is not back on the carriage (%s)"
+                        " -- nothing measured"
+                        % (self.name, tool, carriage.get('state_reason')))
             cylinder_x, cylinder_y = self._cylinder()
             x0, y0 = cylinder_x - self.nozzle_x_shift, cylinder_y
             gcmd.respond_info("T%d: offset calibration, start %.3f, %.3f"
@@ -756,7 +789,8 @@ class FFToolOffset:
 
     cmd_TOOL_LOCATE_SENSOR_help = (
         "Locate the station with an EMPTY carriage (station_x/y/z) "
-        "([PARK=1] [SAVE=1] [PLATE_CHECK=1] [SAMPLES=] [SAMPLES_TOLERANCE=]"
+        "([PARK=1] [SAVE=1] [HOME=1] [PLATE_CHECK=1] [SAMPLES=]"
+        " [SAMPLES_TOLERANCE=]"
         " [SAMPLES_TOLERANCE_RETRIES=] [SAMPLES_RESULT=]"
         " [SAMPLE_RETRACT_DIST=] [PROBE_SPEED=])")
 


### PR DESCRIPTION
XYZ tool calibration refused to start unless the axes were already homed, which just made the operator type the `G28` the commands were about to need anyway.

## What changed

`TOOL_CALIBRATE_TOOL_OFFSET` and `TOOL_LOCATE_SENSOR` now home themselves:

- `_check_homed` reports what is unhomed, runs `G28`, waits, and re-checks. If homing did not take it aborts with `G28 left the axes unhomed` — nothing measured. There is no opt-out parameter: anyone who wants the axes left alone does not run a calibration command.
- The tool pass re-grabs its tool by asking the toolchanger, not by assuming. Homing docks a mounted tool (Z homes on the carriage's eddy sensor), as does the plate check. The re-grab used to be conditional on the plate check having run, so `PLATE_CHECK=0` plus an auto-home would have measured the bare carriage and saved it as a nozzle — ~3.2 mm out in the crash direction. It now checks `current_tool`, picks the tool back up when it is not there, and refuses to measure a carriage it cannot verify.
- `TOOL_LOCATE_SENSOR` loses `PARK=` for the same reason. The station pass needs an empty carriage, so with a toolchanger it always parks; `PARK=0` only claimed "I docked it by hand", which the sensor check right below already decides for itself. One behaviour change falls out: without `[ff_toolchange]` there is no `TOOLCHANGE_PARK` to call and no sensor to ask, so the pass now just runs, where it used to demand `PARK=0` before it would.
- `ff-tool-offset.cfg`, `docs/calibration.md` and `docs/how-calibration-works.md` follow: the standalone `G28` lines drop out of the documented sequences, the error table swaps the old refusal for the new failure message, and the per-command argument lists lose the two parameters.

`G28`, not `G28 O` — Klipper has no `O` flag, and the fork's `G28` wrapper already docks a mounted tool before homing Z.

## Checks

`ff_tool_offset.py` compiles; `qa/static` passes 135 (its errors are all missing-tool guards — `shellcheck` absent, `work/host/bin/apk` unbuilt — and unrelated to these files). Not exercised on hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UfsqVZ3aXL3qxr3BFDS35x
