### PR TITLE
ASSIGN_TOOL: point a sliced file's tool numbers at other tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,29 @@ both printer models or through every real-world workflow.
 
 ## Unreleased
 
-Release preparation and documentation sweep. No firmware behavior is changed
-by this entry.
+### Added
+
+- `ASSIGN_TOOL TOOL=T<n> N=<number>` points a number a sliced file uses at a
+  different tool, so a file sliced for the wrong heads prints without being
+  sliced again. Tool changes and temperatures both follow it. It lasts until
+  the printer restarts and is never saved; `ASSIGN_TOOL RESET=1` undoes it,
+  and `TOOLCHANGE_STATUS` and every print report the mapping in force. A
+  permanent baseline can be set as `tool_number` in `[ff_tool <n>]`.
+- `M104`/`M109` with a `T` now go through that mapping, as
+  klipper-toolchanger's own macros do. Without a `T` they are unchanged and
+  still address the active extruder.
+
+### Changed
+
+- `toolchanger.tool_number`, `tool_numbers`, `tool_names` and
+  `tool T<n>.tool_number` now report the assignable **number** rather than the
+  tool, which is klipper-toolchanger's meaning. They are identical until
+  `ASSIGN_TOOL` is used. Each tool's permanent index is still available as
+  `tool T<n>.physical_number`, and `ff_toolchange.current_tool` is unchanged.
+- `SELECT_TOOL T=<n>` and `TOOLCHANGE INDEX=<n>` take a tool **number** and
+  follow the mapping. To address one particular tool regardless of it, use
+  `SELECT_TOOL TOOL=T<n>` — which is what every macro this project ships now
+  does.
 
 ## v20260827c-melitopol — 2026-08-27
 

--- a/docs/calibration.md
+++ b/docs/calibration.md
@@ -35,8 +35,8 @@ it is the name HelixScreen's wizard and other UIs look for. It expands to:
 
 ```gcode
 TOOL_LOCATE_SENSOR                ; the reference, empty carriage
-{% for tool in printer.toolchanger.tool_numbers %}
-    SELECT_TOOL T={tool}
+{% for tool in printer.ff_toolchange.physical_tools %}
+    SELECT_TOOL TOOL=T{tool}      ; every head, whatever a file calls them
     TOOL_CALIBRATE_TOOL_OFFSET    ; measures whatever is mounted
 {% endfor %}
 ```
@@ -45,7 +45,7 @@ Run those by hand instead when you only want one tool:
 
 ```gcode
 TOOL_LOCATE_SENSOR       ; only if the station or bed was disturbed
-SELECT_TOOL T=2
+SELECT_TOOL TOOL=T2
 TOOL_CALIBRATE_TOOL_OFFSET
 SAVE_CONFIG
 ```
@@ -101,7 +101,7 @@ nozzle descends. A failed run leaves the previous calibration intact.
 | Message | What happened |
 |---|---|
 | `G28 left the axes unhomed (homed: '<axes>')` | Homing was auto-started and did not finish — an endstop or the toolchanger refused. Fix that first; nothing was measured. |
-| `no tool is mounted. SELECT_TOOL T=<0..3> first` | You ran the tool pass with an empty carriage. It would have measured the bare carriage and saved it as a nozzle — ~3.2 mm out, in the direction that crashes. `TOOL_LOCATE_SENSOR` is the one that wants an empty carriage. |
+| `no tool is mounted. SELECT_TOOL TOOL=T<0..3> first` | You ran the tool pass with an empty carriage. It would have measured the bare carriage and saved it as a nozzle — ~3.2 mm out, in the direction that crashes. `TOOL_LOCATE_SENSOR` is the one that wants an empty carriage. |
 | `carriage is not verifiably empty (<reason>) -- the station pass must run with no tool mounted` | `TOOL_LOCATE_SENSOR` with a tool still on, or the dock and grab sensors disagree. `<reason>` names which. |
 | `[ff_toolchange] not loaded` | Config problem, not an operator one: `ff-toolchange.cfg` is not included. |
 

--- a/docs/notes/20-klipper-fork.md
+++ b/docs/notes/20-klipper-fork.md
@@ -80,7 +80,9 @@ distance), `TMCHOME_X_CY`/`TMCHOME_Y_CY` (stallguard homing cycle, reports posit
 
 Virtual SD / print pipeline: `SDCARD_SET_CHANNEL CHANNEL=n`,
 `SDCARD_SET_GCODE_EX_USED_BASE/CHANGED INDEX=i EXTRUDER=Tn` (slicer-tool→physical-tool
-remap), `SDCARD_SET_NEED_CHECK_EX`, `SDCARD_NO_FILAMENT_CHECK_EX`,
+remap; the mod does this as klipper-toolchanger's `ASSIGN_TOOL` instead — see
+docs/toolchange.md "Tool numbers"), `SDCARD_SET_NEED_CHECK_EX`,
+`SDCARD_NO_FILAMENT_CHECK_EX`,
 `SDCARD_SET_PAUSE_STATE`, `SDCARD_CLEAR_REFUELLING`.
 
 Fans/PA: `SET_FAN_M106[P2] ADJUSTED=.. FACTOR=..` (UI fan override scaling),

--- a/docs/notes/25-app-vs-klipper-ownership.md
+++ b/docs/notes/25-app-vs-klipper-ownership.md
@@ -15,7 +15,7 @@ print is driven from Mainsail unless `ff_*` re-provides it.
 | Print lifecycle | prepare (14 steps), preamble, pause (**all hotends off**), resume (staged reheat + re-grab), exit block | no START/END/PAUSE/RESUME macros in stock config | 50-print-lifecycle.md |
 | Z frame | absolute print-start Z offset (~+3.2 mm) computed in `BuildPage::startPrint`; per-tool XY/Z diffs applied on every grab | nothing; eddy `G28 Z` is **not** nozzle zero | 40-offsets.md |
 | Mesh / leveling | app triggers `BED_MESH_CALIBRATE` / `BED_MESH_PROFILE LOAD=…` | executes | 50-print-lifecycle.md |
-| Tool remap | `SDCARD_SET_GCODE_EX_USED_BASE`, `SDCARD_SET_CHANNEL`; fork's `virtual_sdcard` swallows bare `Tn` | executes blindly | 20-klipper-fork.md |
+| Tool remap | `SDCARD_SET_GCODE_EX_USED_BASE`, `SDCARD_SET_CHANNEL`; fork's `virtual_sdcard` swallows bare `Tn` | executes blindly — **ported**, as klipper-toolchanger's `ASSIGN_TOOL` in `ff_toolchange.py`'s tool map (see `docs/toolchange.md`) | 20-klipper-fork.md |
 | LEDs / fans | `SET_LED LED=chamber_led`, `SET_FAN_SPEED FAN=…` enum mapping | bare sections — the chamber light is **ported**: `ff-chamber.cfg` sets `initial_WHITE: 1.0` so it comes up lit without a UI to switch it | `ledControlMgr`, `fanControlMgr` |
 | PLR, timelapse, camera, MQTT/REST, OTA, drying box | app only | none | 60-background.md |
 

--- a/docs/printing.md
+++ b/docs/printing.md
@@ -39,6 +39,22 @@ needed for that.
 No re-slicing is needed: `[ff_print]` applies the print Z offset for any file,
 including ones sliced before the mod existed.
 
+**Sliced for the wrong tools?** If a file expects PETG in T1 but the PETG is
+physically in T3, you do not have to re-slice it — point the number at the
+tool from the console or a macro button:
+
+```
+ASSIGN_TOOL TOOL=T3 N=1     # the file's T1 now means tool T3
+ASSIGN_TOOL RESET=1         # undo
+```
+
+Tool changes *and* temperatures follow it, so the right nozzle heats as well
+as prints. It lasts until the printer restarts, and every print says the
+mapping in its log so a forgotten one cannot quietly ruin a job. Assigning in
+Orca — which filament goes in which extruder, before you slice — does the same
+thing permanently; this is the way out when the file already exists. Full
+detail in [Tool changes](toolchange.md#tool-numbers).
+
 `START_PRINT` options, for the explicit path: `TOOLS=0:220,2:240` every tool
 the file uses with its clean temperature (Orca: `is_extruder_used[n]`; a bare
 `TOOLS=0,2` also works and falls back to `NOZZLE=`) — presence gate and

--- a/docs/toolchange.md
+++ b/docs/toolchange.md
@@ -197,7 +197,7 @@ descends (`PLATE_CHECK=0` or `plate_check: False` skips it). Home, then:
 ```gcode
 CALIBRATE_TOOL_OFFSETS   ; or, by hand:
 TOOL_LOCATE_SENSOR       ; empty carriage, parks the mounted tool for you
-SELECT_TOOL T=0
+SELECT_TOOL TOOL=T0
 TOOL_CALIBRATE_TOOL_OFFSET   ; measures whatever is on the carriage
 SAVE_CONFIG
 ```
@@ -309,8 +309,11 @@ Fool-proofing, in rough priority order:
 for — `toolchanger` (`name`, `status`, `tool`, `tool_number`, `tool_numbers`,
 `tool_names`, `detected_tool`, `detected_tool_number`, `has_detection`) and
 `tool T0..T3` (`active`, `mounted`, `detect_state` = `mounted|absent` from the
-tool's grab sensor, `extruder`, `heater`, `fan`, `gcode_x/y/z_offset`) — and the
-commands they send: `SELECT_TOOL T=<n>` (= `T<n>`), `UNSELECT_TOOL [T=<n>]`
+tool's grab sensor, `extruder`, `heater`, `fan`, `gcode_x/y/z_offset`,
+`tool_number`) — and the
+commands they send — where `T=<n>` is a tool *number* and `TOOL=T<n>` a tool,
+which differ once `ASSIGN_TOOL` has been used ([Tool numbers](#tool-numbers)):
+`SELECT_TOOL T=<n>` (= `T<n>`), `UNSELECT_TOOL [T=<n>]`
 (= `TOOLCHANGE_PARK`), `INITIALIZE_TOOLCHANGER` (state check, no motion),
 `SET_TOOL_TEMPERATURE [T=<n>] TARGET=<t> [WAIT=1]`,
 `VERIFY_TOOL_DETECTED [T=<n>] [ASYNC=…]` and `SELECT_TOOL_ERROR [MESSAGE=…]`.
@@ -343,8 +346,8 @@ Upstream's docking-mode and tool-parameter commands (`TEST_TOOL_DOCKING`,
 `ENTER_DOCKING_MODE`, `SET_TOOL_PARAMETER` and friends) are deliberately
 absent: calibration here is `TOOL_CALIBRATE_TOOL_OFFSET` /
 `TOOL_LOCATE_SENSOR` / `TOOL_Z_ADJUST`, already tied to the factory numbers.
-`ASSIGN_TOOL` is refused — remap tools in the slicer. Nothing to enable; it is
-always on. `part_fan` in `[ff_toolchange]` is what gets reported as each
+`ASSIGN_TOOL` is supported — see [Tool numbers](#tool-numbers) below. Nothing
+to enable; it is always on. `part_fan` in `[ff_toolchange]` is what gets reported as each
 tool's fan (shared `fan_generic fanM106` on this machine). `ff_toolchange`
 itself stays (the printer-database fingerprint keys on it); the new objects
 sit alongside.
@@ -359,7 +362,7 @@ curl -s 'http://PRINTER:7125/printer/objects/query?toolchanger&tool%20T0'
 # tool T0: mounted/active false, detect_state "absent" while docked
 ```
 
-Then `SELECT_TOOL T=0` from the console and poll the query again: `status`
+Then `SELECT_TOOL TOOL=T0` from the console and poll the query again: `status`
 goes `changing`, then `ready` with `tool_number: 0` and `tool T0`
 `detect_state: "mounted"`. HelixScreen's log on connect should read
 `[Moonraker Client] Subscribing to toolchanger + 4 tool objects`, and its
@@ -376,6 +379,85 @@ dialog. Drop `pkgs/helixscreen/payload/helixscreen/config/printer_database.d/fla
 `UNLOAD_FILAMENT` and `PURGE` from [`pkgs/klipper-config/payload/config/ff-filament.cfg`](../pkgs/klipper-config/payload/config/ff-filament.cfg)
 in Settings → Macro Buttons — a user-assigned macro outranks the backend, and
 the parameter dialog picks up `TOOL` / `TEMP` / `PURGE_TEMP` from the macros.
+
+## Tool numbers
+
+A sliced file says `T1`. Which nozzle should that be?
+
+Two different things are called "tool" here, and once they can disagree the
+difference matters everywhere:
+
+- a **tool** is the hardware — its dock, its offsets, its `[ff_tool 1]`
+  section, its `tool T1` status object. It never moves. Written `T1`.
+- a **tool number** is what a file calls it. Assignable. Written `1`.
+
+They start out the same: `T0` is tool T0. `ASSIGN_TOOL` moves a number to
+another tool, so a file sliced for `T0`/`T1` prints when those filaments are
+actually in other heads — no re-slicing, no editing the file.
+
+```
+ASSIGN_TOOL TOOL=T3 N=1     # from now on the file's T1 means tool T3
+ASSIGN_TOOL RESET=1         # back to the configured map
+```
+
+`TOOLCHANGE_STATUS` prints the map every time, so a remap you set an hour ago
+cannot quietly ruin a print, and `START_PRINT` repeats it into the job log.
+
+**Which spelling means which.** This is the whole rule:
+
+| Spelling | Means | Used by |
+|---|---|---|
+| `TOOL=T3` | the **tool** | you, a UI, every macro in this package |
+| `T=1`, bare `T1`, `M104 … T1` | the **number** | the sliced file |
+
+So `SELECT_TOOL TOOL=T3` always grabs tool T3, while `SELECT_TOOL T=1` grabs
+whichever tool answers to 1. `printer["tool T3"]` is always tool T3.
+
+**Temperatures follow the map too.** A multi-tool file keeps the idle tools
+warm, so nearly every temperature command carries an explicit tool:
+
+```gcode
+M104 S180 T0        ; the tool it is about to put down
+M104 S220 T1        ; the tool it is about to pick up
+T1
+M109 S220 T1
+```
+
+Klipper's own `M104` reads `T` as an extruder index and never consults the
+toolchanger, so without help a remap would grab the right nozzle and heat the
+wrong one. `ff-toolchange.cfg` wraps `M104`/`M109` and routes a `T` through
+the map — the same thing klipper-toolchanger does in its `macros.cfg`. With no
+`T` both fall through to stock Klipper and address the active extruder, which
+is always correct.
+
+**Assigning displaces; it does not swap.** `ASSIGN_TOOL TOOL=T3 N=1` leaves
+tool T1 with no number, so bare `T1` no longer reaches it — the command says
+so when it happens. T1 is otherwise untouched: `TOOL=T1`, its dock, its runout
+sensors and its status object all work as before. To swap, assign both ways:
+
+```
+ASSIGN_TOOL TOOL=T3 N=1
+ASSIGN_TOOL TOOL=T1 N=3
+```
+
+**It does not survive a restart**, and `SAVE_CONFIG` will not store it. The
+map answers "where is the filament today", which is not a property of the
+machine. For a permanent baseline — a machine whose heads are cabled in an
+order you would rather not think about again — set `tool_number` in the
+`[ff_tool <n>]` section instead; `RESET=1` returns to that.
+
+`ASSIGN_TOOL` is refused during a toolchange, and during an unpaused print:
+the next `T<n>` would go to a different nozzle, with different offsets, in the
+middle of an object. Pause first if that is what you mean. `RESET=1` is always
+allowed.
+
+Differences from klipper-toolchanger, all deliberate: numbers are bounded to
+`0..3` (a file for this machine emits nothing else, and the bound keeps every
+status list dense); `T0..T3` stay registered for the whole session, with an
+unassigned number explaining itself rather than becoming `Unknown command`;
+`ASSIGN_TOOL` is a flat command rather than a mux one, since the `tool T<n>`
+objects here are read-only views — the wire format is identical either way;
+and `RESET=1` is ours.
 
 ## Reverse-engineering notes
 

--- a/pkgs/klipper-config/payload/config/ff-filament.cfg
+++ b/pkgs/klipper-config/payload/config/ff-filament.cfg
@@ -155,7 +155,7 @@ gcode:
     SET_GCODE_VARIABLE MACRO=_FF_FILAMENT VARIABLE=tool VALUE={tool}
     SET_GCODE_VARIABLE MACRO=_FF_FILAMENT VARIABLE=in_print VALUE={1 if paused else 0}
     SET_GCODE_VARIABLE MACRO=_FF_FILAMENT VARIABLE=saved_chamber_fan VALUE={printer["fan_generic chamber_fan"].speed}
-    M104 S{temp} T{tool}                 ; app: heatManager first, heat while travelling
+    SET_TOOL_TEMPERATURE TOOL=T{tool} TARGET={temp}   ; app: heatManager first, heat while travelling
     {% if 'xyz' not in printer.toolhead.homed_axes %}
         G28                              ; app: homeManager(1,1,1) when not homed
     {% endif %}
@@ -167,7 +167,7 @@ gcode:
         M400
     {% endif %}
     {% if tool != tc.current_tool %}
-        SELECT_TOOL T={tool}             ; grab: applies this tool's offsets, activates its extruder
+        SELECT_TOOL TOOL=T{tool}         ; grab: applies this tool's offsets, activates its extruder
         M400
     {% else %}
         ACTIVATE_EXTRUDER EXTRUDER={extruder}
@@ -206,7 +206,7 @@ gcode:
             UNSELECT_TOOL                ; app: doReleaseExtruderMgr
         {% endif %}
         {% if heat_off %}
-            M104 S0 T{tool}              ; app: heatManager(tool, 0) on exit
+            SET_TOOL_TEMPERATURE TOOL=T{tool} TARGET=0   ; app: heatManager(tool, 0) on exit
         {% endif %}
     {% endif %}
     SET_GCODE_VARIABLE MACRO=_FF_FILAMENT VARIABLE=tool VALUE=-1
@@ -318,7 +318,7 @@ gcode:
     G1 Z{wipe_z} F{ff.clean_wipe_z_feed}             ; app: G1 Z<probeZ+1> F600
     M400
     {% if ff.clean_cool_delta > 0 and temp - ff.clean_cool_delta > 0 %}
-        M104 S{temp - ff.clean_cool_delta} T{tool}   ; app: heatManager(tool, temp-100)
+        SET_TOOL_TEMPERATURE TOOL=T{tool} TARGET={temp - ff.clean_cool_delta}   ; app: heatManager(tool, temp-100)
         TEMPERATURE_WAIT SENSOR={extruder} MAXIMUM={temp - ff.clean_cool_delta + 3}
     {% endif %}
     M106 P1 S0

--- a/pkgs/klipper-config/payload/config/ff-print-macros.cfg
+++ b/pkgs/klipper-config/payload/config/ff-print-macros.cfg
@@ -68,13 +68,39 @@ gcode:
     {% set tc = printer.ff_toolchange %}
     {% set uncalibrated = [] %}
     {% set absent = [] %}
+    ; TOOL and TOOLS are the numbers the FILE uses; calibrated_tools,
+    ; docked_tools and current_tool are HEADS. This is where the two meet, and
+    ; it is the gate, so an unassigned number is refused here -- before any
+    ; heating, homing or grab -- rather than mid-file as an unknown T<n>.
+    {% set heads = [] %}
     {% for t in tools %}
-        {% if t < 0 or t > 3 %}
-            { action_raise_error("TOOLS: tool %s out of range 0..3" % t) }
+        {% if t < 0 or t >= tc.physical_map|length %}
+            { action_raise_error("TOOLS: T%s is out of range 0..%d -- a file for this machine only names T0..T%d"
+                % (t, tc.physical_map|length - 1, tc.physical_map|length - 1)) }
         {% endif %}
-        {% if t not in tc.calibrated_tools %}{% set _ = uncalibrated.append(t) %}{% endif %}
-        {% if t not in tc.docked_tools and t != tc.current_tool %}{% set _ = absent.append(t) %}{% endif %}
+        {% set head = tc.physical_map[t] %}
+        {% if head < 0 %}
+            { action_raise_error("T%s is not assigned to any tool (map: %s). Assign one with "
+                "ASSIGN_TOOL TOOL=T<n> N=%s, or ASSIGN_TOOL RESET=1." % (t, tc.tool_map, t)) }
+        {% endif %}
+        {% set _ = heads.append(head) %}
+        {% if head not in tc.calibrated_tools %}{% set _ = uncalibrated.append(head) %}{% endif %}
+        {% if head not in tc.docked_tools and head != tc.current_tool %}
+            {% set _ = absent.append("T%d%s" % (head, "" if head == t else " (the file's T%d)" % t)) %}
+        {% endif %}
     {% endfor %}
+    ; A map nobody remembers setting is a wrong print with no visible cause,
+    ; so say it every time -- here rather than in START_PRINT, because the
+    ; touchscreen/M23 path reaches this macro and not that one.
+    {% if not tc.tool_map_identity %}
+        {% if tools|length > 0 %}
+            {% for t in tools %}
+                { action_respond_info("TOOL MAP: the file's T%d is tool T%d" % (t, tc.physical_map[t])) }
+            {% endfor %}
+        {% else %}
+            { action_respond_info("TOOL MAP is not identity: %s. ASSIGN_TOOL RESET=1 restores it." % tc.tool_map) }
+        {% endif %}
+    {% endif %}
     {% set ok = (tools|length > 0 and uncalibrated|length == 0 and tc.station_z is not none)
                 or (tools|length == 0 and tc.print_offset_ready) %}
     {% if not ok and not printer["gcode_macro _FF_JOB"].allow_uncalibrated %}
@@ -82,15 +108,16 @@ gcode:
             "Run TOOL_LOCATE_SENSOR / TOOL_CALIBRATE_TOOL_OFFSET (or FF_IMPORT_FIRMWARE_CONFIG) "
             "and SAVE_CONFIG. Without nozzle_z/station_z the print Z offset cannot be "
             "computed and the nozzle would be driven ~3 mm into the plate."
-            % (tc.station_z, tc.calibrated_tools, tools)) }
+            % (tc.station_z, tc.calibrated_tools, heads)) }
     {% endif %}
     {% if tools|length > 0 and not tc.state_ok %}
         { action_raise_error("Toolchanger state not ok: %s" % tc.state_reason) }
     {% endif %}
     {% if absent|length > 0 %}
         { action_raise_error("Tool(s) %s not installed (dock switch not pressed, not mounted); "
-            "docked %s, mounted T%s. Install them or re-slice without them."
-            % (absent, tc.docked_tools, tc.current_tool)) }
+            "docked %s, mounted T%s. Install them, re-slice without them, or point the "
+            "file's numbers at tools you have with ASSIGN_TOOL."
+            % (absent|join(', '), tc.docked_tools, tc.current_tool)) }
     {% endif %}
 
 # ---------------------------------------------------------------------------
@@ -163,7 +190,25 @@ gcode:
     {% endfor %}
     {% if tools|length == 0 and tool >= 0 %}{% set _ = tools.append(tool) %}{% endif %}
     {% set tool_list = tools|join(',') %}
-    {% set temps = [tmap.get(0, 0), tmap.get(1, 0), tmap.get(2, 0), tmap.get(3, 0)]|join(',')
+    ; TOOL and TOOLS are the numbers the FILE uses -- [initial_extruder] from
+    ; the slicer, or what [ff_print] read out of the file's first Tn. The map
+    ; turns them into HEADS, which is what everything below needs: the clean
+    ; indexes tool_material and printer["tool T<n>"] by head, and the grab has
+    ; to reach one particular nozzle. Translate once, here.
+    ; _FF_PREFLIGHT is handed the file's own numbers and is what refuses an
+    ; out-of-range or unassigned one -- it runs before any head below is used.
+    {% set tc = printer.ff_toolchange %}
+    {% set heads = [] %}
+    {% for n in tools %}
+        {% set _ = heads.append(tc.physical_map[n] if 0 <= n and n < tc.physical_map|length else -1) %}
+    {% endfor %}
+    {% set head = tc.physical_map[tool] if 0 <= tool and tool < tc.physical_map|length else -1 %}
+    {% set head_list = heads|join(',') %}
+    ; TEMPS is positional by head, because that is how _FF_NOZZLE_CLEAN reads
+    ; it; the file gave them to us keyed by number.
+    {% set by_head = [] %}
+    {% for p in tc.physical_tools %}{% set _ = by_head.append(tmap.get(tc.tool_map[p], 0)) %}{% endfor %}
+    {% set temps = by_head|join(',')
                    if tmap else params.TEMPS|default('')|string|trim %}
     _FF_PREFLIGHT TOOL={tool}{% if tool_list %} TOOLS={tool_list}{% endif %}
     G90
@@ -176,7 +221,7 @@ gcode:
         M140 S{bed}                      ; app: heatManager(bed) -- heats during the clean
     {% endif %}
     {% if clean and tools|length > 0 %}
-        _FF_NOZZLE_CLEAN TOOLS={tool_list}{% if temps %} TEMPS={temps}{% endif %} TEMP={nozzle}
+        _FF_NOZZLE_CLEAN TOOLS={head_list}{% if temps %} TEMPS={temps}{% endif %} TEMP={nozzle}
         M106 P1 S0                       ; app @0x9f27a4
     {% endif %}
     {% if bed > 0 %}
@@ -200,10 +245,10 @@ gcode:
                                          ; eddy frame sits ~3.2 mm low, so
                                          ; nominal Z10 is ~6.8 mm physical
     {% endif %}
-    {% if tool >= 0 %}
-        M104 S{nozzle} T{tool}           ; app: heatManager(active tool, print temp) @0x9f3348
-        T{tool}                          ; grab first tool (ff_toolchange)
-        TOOLCHANGE_SET_PRINT_OFFSET NOZZLE={nozzle} BED={bed} LAYER={layer} TOOL={tool}
+    {% if head >= 0 %}
+        SET_TOOL_TEMPERATURE TOOL=T{head} TARGET={nozzle}   ; app: heatManager(active tool, print temp) @0x9f3348
+        SELECT_TOOL TOOL=T{head}         ; grab first tool (ff_toolchange)
+        TOOLCHANGE_SET_PRINT_OFFSET NOZZLE={nozzle} BED={bed} LAYER={layer} TOOL=T{head}
     {% else %}
         TOOLCHANGE_SET_PRINT_OFFSET NOZZLE={nozzle} BED={bed} LAYER={layer}
     {% endif %}
@@ -315,10 +360,11 @@ gcode:
         SET_GCODE_VARIABLE MACRO=PAUSE VARIABLE=t2 VALUE={printer.extruder2.target}
         SET_GCODE_VARIABLE MACRO=PAUSE VARIABLE=t3 VALUE={printer.extruder3.target}
         BASE_PAUSE                       ; stops SD + saves position/state
-        M104 S0 T0
-        M104 S0 T1
-        M104 S0 T2
-        M104 S0 T3
+        ; By head, not by number: these are the four hotends, whatever the
+        ; file calls them.
+        {% for t in printer.ff_toolchange.physical_tools %}
+            SET_TOOL_TEMPERATURE TOOL=T{t} TARGET=0
+        {% endfor %}
         {% if 'z' in printer.toolhead.homed_axes %}
             {% set z = printer.toolhead.position.z %}
             {% set park = [z + 10.0, 256.0]|min %}
@@ -338,14 +384,15 @@ gcode:
         { action_respond_info("not paused") }
     {% else %}
         {% set p = printer["gcode_macro PAUSE"] %}
-        {% if p.t0 > 0 %} M104 S{p.t0} T0 {% endif %}
-        {% if p.t1 > 0 %} M104 S{p.t1} T1 {% endif %}
-        {% if p.t2 > 0 %} M104 S{p.t2} T2 {% endif %}
-        {% if p.t3 > 0 %} M104 S{p.t3} T3 {% endif %}
-        {% if p.t0 > 0 %} M109 S{p.t0} T0 {% endif %}
-        {% if p.t1 > 0 %} M109 S{p.t1} T1 {% endif %}
-        {% if p.t2 > 0 %} M109 S{p.t2} T2 {% endif %}
-        {% if p.t3 > 0 %} M109 S{p.t3} T3 {% endif %}
+        ; PAUSE snapshotted each EXTRUDER's target, so these are heads. Two
+        ; passes, as before: ask for every target first, then wait, so four
+        ; hotends heat together instead of one after another.
+        {% for t in printer.ff_toolchange.physical_tools %}
+            {% if p['t' ~ t] > 0 %} SET_TOOL_TEMPERATURE TOOL=T{t} TARGET={p['t' ~ t]} {% endif %}
+        {% endfor %}
+        {% for t in printer.ff_toolchange.physical_tools %}
+            {% if p['t' ~ t] > 0 %} SET_TOOL_TEMPERATURE TOOL=T{t} TARGET={p['t' ~ t]} WAIT=1 {% endif %}
+        {% endfor %}
         SET_IDLE_TIMEOUT TIMEOUT=864000
         {% if printer.ff_toolchange.current_tool >= 0 %}
             FF_RUNOUT_ARM                ; app re-arms the clog sensor after

--- a/pkgs/klipper-config/payload/config/ff-tool-offset.cfg
+++ b/pkgs/klipper-config/payload/config/ff-tool-offset.cfg
@@ -14,7 +14,7 @@
 # The station sits BELOW the bed plane, so the build plate has to come off --
 # not asked for as a flag: the plate check parks the carriage and measures.
 #
-#   TOOL_CALIBRATE_TOOL_OFFSET  the MOUNTED tool (SELECT_TOOL T=<n> first):
+#   TOOL_CALIBRATE_TOOL_OFFSET  the MOUNTED tool (SELECT_TOOL TOOL=T<n> first):
 #       zero the G-code offset, go to (cylinder_x - 12.5, cylinder_y), ESTOP Z
 #       to z_target, four ESTOP probes outward (+X +Y -X -Y, 14 mm) at Z+0.6,
 #       circle fit, second pass centred on that fit with Z re-probed, store as
@@ -116,7 +116,12 @@
 description: Remove the build plate and clean all nozzles first. Calibrates the station, then the nozzle offset of every tool.
 gcode:
     TOOL_LOCATE_SENSOR
-    {% for tool in printer.toolchanger.tool_numbers %}
-        SELECT_TOOL T={tool}
+    ; Every HEAD, deliberately not toolchanger.tool_numbers: calibration is
+    ; about nozzles, and tool_numbers is about what a file calls them. Under
+    ; a remap that list can be short a number, and TOOL_CALIBRATE_TOOL_OFFSET
+    ; saves against the mounted head either way -- so a number-driven loop
+    ; would skip a tool and write another tool's measurement into its section.
+    {% for tool in printer.ff_toolchange.physical_tools %}
+        SELECT_TOOL TOOL=T{tool}
         TOOL_CALIBRATE_TOOL_OFFSET
     {% endfor %}

--- a/pkgs/klipper-config/payload/config/ff-toolchange.cfg
+++ b/pkgs/klipper-config/payload/config/ff-toolchange.cfg
@@ -53,6 +53,11 @@
 # `Tn`, which reaches ff_toolchange.py's T<n> unimpeded. Files sliced with the
 # older `T{next_extruder} ; ff-toolchange` marker still work.
 #
+# That `Tn` is a NUMBER, not a tool: ASSIGN_TOOL TOOL=T3 N=1 makes the file's
+# T1 mean tool T3, so a file sliced for the wrong heads prints without being
+# sliced again. Runtime only -- a restart puts it back. See docs/toolchange.md
+# "Tool numbers"; tool_number below is the baseline it starts from.
+#
 # INSTALL. Flashing a package built from this repo is the whole install. By
 # hand, onto a printer that is already modded:
 #   1. cp payload/klipper/extras/ff_*.py /usr/data/anvil/klipper/klippy/extras/
@@ -72,6 +77,15 @@
 # nozzle calibration are per unit and live in printer.cfg's SAVE_CONFIG block,
 # filled by FF_IMPORT_FIRMWARE_CONFIG. A tool without a dock refuses to be
 # grabbed or released.
+#
+# tool_number is the one option that belongs here rather than in SAVE_CONFIG:
+# the number a sliced file uses for this tool, defaulting to the tool's own
+# index. It is the BASELINE the map starts from and ASSIGN_TOOL RESET=1
+# returns to -- not the live assignment, which is never written anywhere. Set
+# it only for a machine whose heads are cabled in an order you would rather
+# not think about again; for one print, use ASSIGN_TOOL.
+#   [ff_tool 3]
+#   tool_number: 1
 [ff_tool 0]
 
 [ff_tool 1]
@@ -96,7 +110,7 @@
 #offset_base: 0
 # Reported as each tool's `fan` in the klipper-toolchanger-shaped status
 # (objects `toolchanger` and `tool T0..T3` are always registered, so UIs such
-# as HelixScreen see a real toolchanger; ASSIGN_TOOL is refused).
+# as HelixScreen see a real toolchanger, ASSIGN_TOOL included).
 #part_fan: fan_generic fanM106
 
 # Homing safety. firmwareExe auto-homes before a grab, but a remote T<n>

--- a/pkgs/klipper-config/payload/config/ff-toolchange.cfg
+++ b/pkgs/klipper-config/payload/config/ff-toolchange.cfg
@@ -189,7 +189,7 @@ gcode:
     {% endif %}
     {% if tc.current_tool < 0 %}
         { action_respond_info("no tool mounted -- grabbing T%d for the resonance test" % shaper_tool) }
-        T{shaper_tool}
+        SELECT_TOOL TOOL=T{shaper_tool}
     {% endif %}
 
 [gcode_macro SHAPER_CALIBRATE]
@@ -256,3 +256,52 @@ rename_existing: _FF_STEPPER_RESONANCE_REFINE_CALIBRATE_BASE
 gcode:
     _FF_SHAPER_PREP
     _FF_STEPPER_RESONANCE_REFINE_CALIBRATE_BASE {rawparams}
+
+# ---------------------------------------------------------------------------
+# M104 / M109 -- the file's T<n> is a NUMBER, so its temperatures follow the
+# tool map too.
+#
+# Klipper's own M104 reads T as an EXTRUDER INDEX (kinematics/extruder.py
+# cmd_M104: 'extruder' or 'extruder<T>'), which bypasses the toolchanger
+# entirely. Without this pair ASSIGN_TOOL would grab the right head and heat
+# the wrong one -- and a real multi-tool file puts an explicit T on nearly
+# every temperature command, because it keeps the idle tools warm while the
+# active one prints:
+#
+#     M104 S180 T0        ; the tool it is about to put down
+#     M104 S220 T1        ; the tool it is about to pick up
+#     T1
+#     M109 S220 T1
+#
+# klipper-toolchanger does this in its shipped macros.cfg rather than in the
+# extra, and so do we: the module owns which tool is which, the config owns
+# rewriting standard G-code, and a machine that does not include this file
+# keeps stock behaviour.
+#
+# With NO T both fall straight through to Klipper's own command, which
+# addresses the ACTIVE extruder -- always right, and never the map's business.
+# That is also why nothing in this package emits `M104 ... T` any more: our
+# own macros mean a head and say SET_TOOL_TEMPERATURE TOOL=T<n>. Putting an
+# `M104 S0 T0` back into a macro would silently send it through the map, which
+# is what test_no_shipped_macro_sets_a_temperature_by_M104_T watches for.
+#
+# One difference from stock M109: SET_TOOL_TEMPERATURE WAIT=1 waits for
+# heat-UP only (TEMPERATURE_WAIT MINIMUM) where M109 waits for a band. On the
+# way down there is nothing to wait for, and a target of 0 never arrives.
+[gcode_macro M104]
+rename_existing: M104.1
+gcode:
+    {% if 'T' in params %}
+        SET_TOOL_TEMPERATURE T={params.T|int} TARGET={params.S|default(0)|float}
+    {% else %}
+        M104.1 {rawparams}
+    {% endif %}
+
+[gcode_macro M109]
+rename_existing: M109.1
+gcode:
+    {% if 'T' in params %}
+        SET_TOOL_TEMPERATURE T={params.T|int} TARGET={params.S|default(0)|float} WAIT=1
+    {% else %}
+        M109.1 {rawparams}
+    {% endif %}

--- a/pkgs/klipper/payload/klipper/klippy/extras/ff_pa.py
+++ b/pkgs/klipper/payload/klipper/klippy/extras/ff_pa.py
@@ -307,11 +307,13 @@ class FFPA:
         tool = gcmd.get_int('TOOL', current, minval=0,
                             maxval=EXTRUDER_COUNT - 1)
         if tool != current:
-            self._run('SELECT_TOOL T=%d' % tool)
+            # By NAME: TOOL= here is a head (pressure advance is a property
+            # of the extruder), and T= would send it through the tool map.
+            self._run('SELECT_TOOL TOOL=T%d' % tool)
             self._wait_moves()
         elif current < 0:
             raise gcmd.error(
-                "%s: no tool is mounted. SELECT_TOOL T=<0..%d> first, or"
+                "%s: no tool is mounted. SELECT_TOOL TOOL=T<0..%d> first, or"
                 " pass TOOL=." % (self.name, EXTRUDER_COUNT - 1))
         return tool
 
@@ -344,7 +346,8 @@ class FFPA:
             return
         raise gcmd.error(
             "%s: %s is at %.1f C and will not extrude (min_extrude_temp)."
-            " Heat it -- M109 S<temp> T<tool> -- or pass TEMP=."
+            " Heat it -- SET_TOOL_TEMPERATURE TOOL=T<n> TARGET=<temp> WAIT=1"
+            " -- or pass TEMP=."
             % (self.name, extruder.get_name(), status.get('temperature', 0.)))
 
     def _check_filament(self, gcmd, tool):
@@ -757,7 +760,7 @@ class FFPA:
         if temp is None:
             return None
         prev = extruder.get_status(self.reactor.monotonic()).get('target', 0.)
-        self._run('M104 S%.1f T%d' % (temp, tool))
+        self._run('SET_TOOL_TEMPERATURE TOOL=T%d TARGET=%.1f' % (tool, temp))
         self._run('TEMPERATURE_WAIT SENSOR=%s MINIMUM=%.1f MAXIMUM=%.1f'
                   % (extruder.get_name(), temp - self.min_temp_margin,
                      temp + self.min_temp_margin))
@@ -767,7 +770,8 @@ class FFPA:
         if prev_target is None:
             return
         try:
-            self._run('M104 S%.1f T%d' % (prev_target, tool))
+            self._run('SET_TOOL_TEMPERATURE TOOL=T%d TARGET=%.1f'
+                      % (tool, prev_target))
         except self.printer.command_error:
             pass
 

--- a/pkgs/klipper/payload/klipper/klippy/extras/ff_tool.py
+++ b/pkgs/klipper/payload/klipper/klippy/extras/ff_tool.py
@@ -39,6 +39,13 @@ class FFTool:
                                % self.name)
         if self.index < 0:
             raise config.error("%s: tool index must be >= 0" % self.name)
+        # The number a sliced file uses for this tool, as klipper-toolchanger's
+        # [tool] tool_number. Hand-written, never autosaved: it is the BASELINE
+        # the map starts from and ASSIGN_TOOL RESET=1 returns to, not the live
+        # assignment. Upstream defaults to -1 (unnumbered); the section index
+        # is the default here because identity is this machine's baseline and a
+        # tool no `T<n>` reaches would be a footgun, not a feature.
+        self.tool_number = config.getint('tool_number', self.index, minval=0)
         # Dock position (FF_IMPORT_FIRMWARE_CONFIG) -- both or neither.
         self.dock_x = config.getfloat('dock_x', None)
         self.dock_y = config.getfloat('dock_y', None)
@@ -107,7 +114,8 @@ class FFTool:
     def get_status(self, eventtime):
         nozzle_x, nozzle_y, nozzle_z = (self.nozzle if self.nozzle
                                         else (None, None, None))
-        return {'index': self.index, 'dock_x': self.dock_x,
+        return {'index': self.index, 'tool_number': self.tool_number,
+                'dock_x': self.dock_x,
                 'dock_y': self.dock_y, 'extruder': self.extruder_name,
                 'z_adjust': self.z_adjust,
                 'calibrated': self.nozzle is not None,

--- a/pkgs/klipper/payload/klipper/klippy/extras/ff_tool_offset.py
+++ b/pkgs/klipper/payload/klipper/klippy/extras/ff_tool_offset.py
@@ -693,7 +693,7 @@ class FFToolOffset:
 
     def cmd_TOOL_CALIBRATE_TOOL_OFFSET(self, gcmd):
         """klipper-toolchanger's signature: no arguments, measures whatever
-        is on the carriage. Select the tool first (SELECT_TOOL T=<n>, or
+        is on the carriage. Select the tool first (SELECT_TOOL TOOL=T<n>, or
         T<n>), exactly as upstream's CALIBRATE_TOOL_OFFSETS loop does."""
         if self.toolchange is None:
             raise gcmd.error("%s: [ff_toolchange] not loaded -- there is no"
@@ -702,7 +702,7 @@ class FFToolOffset:
             self.reactor.monotonic()).get('current_tool', -1)
         if tool < 0:
             raise gcmd.error(
-                "%s: no tool is mounted. SELECT_TOOL T=<0..%d> first --"
+                "%s: no tool is mounted. SELECT_TOOL TOOL=T<0..%d> first --"
                 " this measures the tool on the carriage, and with an empty"
                 " one it would save the bare carriage as a nozzle position,"
                 " ~3.2 mm out in the crash direction. (TOOL_LOCATE_SENSOR"
@@ -719,7 +719,12 @@ class FFToolOffset:
             # nozzle position ~3.2 mm out in the crash direction.
             carriage = self.toolchange.get_status(self.reactor.monotonic())
             if carriage.get('current_tool', -1) != tool:
-                self._run('T%d' % tool)
+                # By NAME, not a bare T<n>: `tool` is the head this
+                # measurement will be saved against, and a bare T<n> goes
+                # through the tool map. Under a remap it would grab a
+                # different head and store its nozzle position in this tool's
+                # section -- a wrong nozzle_z, ~3 mm in the crash direction.
+                self._run('SELECT_TOOL TOOL=T%d' % tool)
                 self._wait_moves()
                 carriage = self.toolchange.get_status(self.reactor.monotonic())
                 if carriage.get('current_tool', -1) != tool \
@@ -763,7 +768,7 @@ class FFToolOffset:
                 tool_object.set_nozzle(center_x, center_y, z_trigger)
 
             # the app's exit block: heater off for the tool, Z15
-            self._run('M104 S0 T%d' % tool)
+            self._run('SET_TOOL_TEMPERATURE TOOL=T%d TARGET=0' % tool)
             self._run('G1 Z%.3f F%d' % (self.z_final, FEED_PASS1))
             self._run('M400')
             if save:

--- a/pkgs/klipper/payload/klipper/klippy/extras/ff_toolchange.py
+++ b/pkgs/klipper/payload/klipper/klippy/extras/ff_toolchange.py
@@ -1596,13 +1596,61 @@ class FFToolchange:
                           % (mounted, reason, frame,
                              "" if before == after else " -- re-applied"))
 
-    cmd_ASSIGN_TOOL_help = "Not supported on this toolchanger"
+    cmd_ASSIGN_TOOL_help = ("Point a number a file uses at a tool"
+                            " (TOOL=T<n> N=<number>), or RESET=1 to restore"
+                            " the configured map. Runtime only")
 
     def cmd_ASSIGN_TOOL(self, gcmd):
-        raise gcmd.error(
-            "ASSIGN_TOOL: logical-to-physical tool remapping is not supported"
-            " here; remap in the slicer (the fork's"
-            " SDCARD_SET_GCODE_EX_USED_BASE table is the future home)")
+        """klipper-toolchanger's ASSIGN_TOOL TOOL=<name> N=<number>.
+
+        Upstream registers this as a mux command keyed on each tool object's
+        name. Ours is flat, because the `tool T<n>` objects here are
+        read-only status views with no command surface of their own -- on the
+        wire the two are the same thing, and a UI sending upstream's spelling
+        reaches this.
+
+        Nothing is persisted, deliberately. The map answers "where is the
+        filament today", which is not a property of the machine, and
+        SAVE_CONFIG restarts klippy -- so a mid-session remap could not use it
+        anyway. A restart is the reset.
+        """
+        if gcmd.get_int('RESET', 0):
+            self.tool_map.reset()
+            self._report_map(gcmd, "tool map reset")
+            return
+        if self.changing:
+            raise gcmd.error("ASSIGN_TOOL: a toolchange is running")
+        # Mid-print the next T<n> would go to a different head, with different
+        # offsets, in the middle of an object. Paused is fine -- that is when
+        # somebody swaps a spool and wants the file pointed at another tool.
+        print_stats = self.printer.lookup_object('print_stats', None)
+        pause_resume = self.printer.lookup_object('pause_resume', None)
+        if print_stats is not None:
+            state = print_stats.get_status(
+                self.reactor.monotonic()).get('state')
+            paused = (pause_resume is not None and pause_resume.get_status(
+                self.reactor.monotonic()).get('is_paused'))
+            if state == 'printing' and not paused:
+                raise gcmd.error(
+                    "ASSIGN_TOOL: a print is running. Remapping now would"
+                    " send the next T<n> to a different nozzle mid-object."
+                    " PAUSE first if that is what you mean.")
+        tool = self._physical_arg(gcmd)
+        number = gcmd.get_int('N', minval=0, maxval=EXTRUDER_COUNT - 1)
+        if self.tool_map.number_of(tool) == number:
+            self._report_map(gcmd, "T%d already answers to %d" % (tool, number))
+            return
+        displaced = self.tool_map.assign(tool, number)
+        headline = "T%d now answers to %d" % (tool, number)
+        if displaced != _ToolMap.UNSET:
+            headline += ("; T%d has no number and bare T%d no longer reaches"
+                         " it -- give it one, or ASSIGN_TOOL RESET=1"
+                         % (displaced, displaced))
+        self._report_map(gcmd, headline)
+
+    def _report_map(self, gcmd, headline):
+        gcmd.respond_info("%s\n%s"
+                          % (headline, "\n".join(self.tool_map.describe())))
 
     cmd_SET_TOOL_TEMPERATURE_help = (
         "Set a tool's hotend target (T=<n> | TOOL=T<n>, default the mounted"
@@ -1702,6 +1750,11 @@ class FFToolchange:
         else:
             lines = ["current_tool=%d  (%s)" % (tool, reason)]
         lines.append("  (derived from the dock sensors; nothing is stored)")
+        # First thing after the tool, because everything below it is printed
+        # in HEADS and a reader who does not know the map is misreading all
+        # of it. Said even when it is the identity, so its presence is a
+        # habit and its absence is noticeable.
+        lines.extend("  " + line for line in self.tool_map.describe())
         applied = self.gcode_transform.tool
         if applied is None:
             lines.append("  frame applied: NONE -- raw machine coordinates."

--- a/pkgs/klipper/payload/klipper/klippy/extras/ff_toolchange.py
+++ b/pkgs/klipper/payload/klipper/klippy/extras/ff_toolchange.py
@@ -82,15 +82,21 @@ class _ToolchangerView:
         # reports. We keep no commanded state -- every answer is derived from
         # the dock and grab sensors -- so the two are the same by
         # construction, and both are reported for UIs that read only one.
+        # Upstream's split, and the reason `tool` and `tool_number` can
+        # disagree now: the NAME is the tool itself and matches the object
+        # name a UI subscribes to, while the NUMBER is the assignment.
         name = 'T%d' % mounted if mounted >= 0 else None
+        number = own['current_number']
+        tool_map = self.toolchanger.tool_map
         return {'name': 'toolchanger',
                 'status': status,
-                'tool_number': mounted,
-                'tool_numbers': list(range(EXTRUDER_COUNT)),
-                'tool_names': ['T%d' % i for i in range(EXTRUDER_COUNT)],
+                'tool_number': number,
+                'tool_numbers': tool_map.numbers(),
+                'tool_names': tool_map.names(),
                 'tool': name,
                 'detected_tool': name,
-                'detected_tool_number': mounted,
+                'detected_tool_number': number,
+                'tool_map': tool_map.as_list(),
                 'has_detection': True,
                 'state_reason': own['state_reason'],
                 # The print-scoped Z the tool frame is carrying on top of
@@ -120,7 +126,12 @@ class _ToolView:
                       else 'absent')
         except (FFToolchangeError, IndexError):
             detect = 'unavailable'
-        return {'tool_number': self.index,
+        # tool_number is upstream's: the assignable number, -1 when this tool
+        # answers to none. physical_number is what tool_number used to mean
+        # and never moves; `name` stays physical because it must keep matching
+        # this object's own name.
+        return {'tool_number': toolchanger.tool_map.number_of(self.index),
+                'physical_number': self.index,
                 'name': 'T%d' % self.index,
                 'toolchanger': 'toolchanger',
                 'active': mounted == self.index,
@@ -207,6 +218,111 @@ class _ToolTransform:
                 base[2] - offsets[2]] + list(base[3:])
 
 
+class _ToolMap:
+    """Which physical tool answers each number a G-code file names.
+
+    Two vocabularies meet here and must not be confused. A PHYSICAL tool is
+    the hardware: 0..3, the [ff_tool <n>] section, the dock switch, the
+    offsets, the error-code addend, the `tool T<n>` status object. It never
+    moves. A NUMBER is what a sliced file says -- bare `T1`, `M104 S220 T1`
+    -- and ASSIGN_TOOL points it at whichever tool holds the right filament,
+    so a file sliced for T0/T1 prints without being sliced again.
+
+    Assigning DISPLACES rather than swaps, as klipper-toolchanger does: the
+    tool that held the number is left unnumbered, not handed the assigner's
+    old number. Moving a second tool is not what the operator typed. A
+    displaced tool is still entirely reachable -- TOOL=T1, its dock, its
+    runout sensors, its status object -- and only bare `T1` stops resolving,
+    which reports itself rather than becoming an unknown command.
+
+    Numbers are bounded to 0..count-1. Upstream allows any number because it
+    also serves MMUs with a variable tool count; here the bound is what keeps
+    inverse() a dense list, keeps _FF_PREFLIGHT's range check honest and
+    keeps ff_print.py's ^T([0-3]) file regex complete.
+
+    Deliberately free of printer, config and gcode. The replica cannot reach
+    a klippy ready phase -- no MCU ports, see qa/replica/test_mcu_bringup.py
+    -- so a map that needed a live printer to exercise would ship untested.
+    """
+
+    UNSET = -1
+
+    def __init__(self, baseline):
+        self.count = len(baseline)
+        self.baseline = list(baseline)
+        self._number = list(baseline)
+
+    def reset(self):
+        """Back to the configured baseline, i.e. [ff_tool <n>].tool_number."""
+        self._number = list(self.baseline)
+
+    def assign(self, physical, number):
+        """Give `physical` this number; returns the tool displaced, or -1."""
+        displaced = self.physical_of(number)
+        if displaced == physical:
+            return self.UNSET
+        if displaced != self.UNSET:
+            self._number[displaced] = self.UNSET
+        self._number[physical] = number
+        return displaced
+
+    def number_of(self, physical):
+        return self._number[physical]
+
+    def physical_of(self, number):
+        if number is None or number < 0:
+            return self.UNSET
+        try:
+            return self._number.index(number)
+        except ValueError:
+            return self.UNSET
+
+    def is_identity(self):
+        """Against TRUE identity, not the configured baseline -- a machine
+        that configures a permanent remap earns the same standing notice."""
+        return self._number == list(range(self.count))
+
+    def numbers(self):
+        """Assigned numbers, sorted. klipper-toolchanger's tool_numbers."""
+        return sorted(n for n in self._number if n != self.UNSET)
+
+    def names(self):
+        """Physical names, PARALLEL to numbers() -- upstream's invariant."""
+        return ['T%d' % self.physical_of(n) for n in self.numbers()]
+
+    def as_list(self):
+        """Index = physical tool, value = its number (-1 unnumbered)."""
+        return list(self._number)
+
+    def inverse(self):
+        """Index = number, value = the physical tool (-1 unassigned)."""
+        return [self.physical_of(n) for n in range(self.count)]
+
+    def describe(self):
+        """The lines TOOLCHANGE_STATUS and ASSIGN_TOOL both print."""
+        if self.is_identity():
+            return ["tool map: identity (the file's T<n> is tool T<n>)"]
+        lines = ["! TOOL MAP IS NOT IDENTITY -- the file's T<n> is not the"
+                 " tool it names:"]
+        for number in range(self.count):
+            physical = self.physical_of(number)
+            if physical == self.UNSET:
+                lines.append("    file T%d  ->  NOTHING -- bare T%d is"
+                             " refused" % (number, number))
+            else:
+                lines.append("    file T%d  ->  tool T%d%s"
+                             % (number, physical,
+                                "" if physical == number else "   <- assigned"))
+        unnumbered = [p for p in range(self.count)
+                      if self._number[p] == self.UNSET]
+        for physical in unnumbered:
+            lines.append("    tool T%d has no number -- reach it with"
+                         " TOOL=T%d" % (physical, physical))
+        lines.append("  Runtime only: a klippy restart or ASSIGN_TOOL RESET=1"
+                     " restores the configured map.")
+        return lines
+
+
 class FFToolchangeError(Exception):
     """A toolchange step failed or the sensors report an unusable state."""
 
@@ -230,6 +346,29 @@ class FFToolchange:
                     "%s: section [ff_tool %d] is required (an empty"
                     " section is enough; FF_IMPORT_FIRMWARE_CONFIG fills"
                     " in dock and nozzle data)" % (self.name, i))
+        # Which physical tool answers each number a file names. Seeded from
+        # the hand-written [ff_tool <n>] tool_number values, moved at runtime
+        # by ASSIGN_TOOL, never persisted.
+        baseline = [tool.tool_number for tool in self.tools]
+        for number in set(baseline):
+            holders = [i for i, n in enumerate(baseline) if n == number]
+            if len(holders) > 1:
+                raise config.error(
+                    "%s: tool_number %d is claimed by %s -- each number may"
+                    " name only one tool"
+                    % (self.name, number,
+                       " and ".join("[ff_tool %d]" % i for i in holders)))
+        for i, number in enumerate(baseline):
+            if number >= EXTRUDER_COUNT:
+                raise config.error(
+                    "%s: [ff_tool %d] tool_number %d is out of range 0..%d;"
+                    " a file for this machine only ever emits T0..T%d"
+                    % (self.name, i, number, EXTRUDER_COUNT - 1,
+                       EXTRUDER_COUNT - 1))
+        self.tool_map = _ToolMap(baseline)
+        # T<n> names this module registered itself, so that a user's own
+        # [gcode_macro T5] is never displaced -- upstream's rule.
+        self.owned_numbers = set()
         # testConfig()+8 grabOffset in the app.
         self.x_correction = config.getfloat('x_correction', 0.0)
         # degC-to-mm thermal term of the print-start Z offset
@@ -343,9 +482,7 @@ class FFToolchange:
 
         self.gcode.register_command(
             'TOOLCHANGE', self.cmd_TOOLCHANGE, desc=self.cmd_TOOLCHANGE_help)
-        for i in range(EXTRUDER_COUNT):
-            self.gcode.register_command(
-                'T%d' % i, self._make_tn(i), desc="Select tool %d" % i)
+        # T<n> is registered at connect, not here -- see _register_t_commands.
         self.gcode.register_command(
             'TOOLCHANGE_STATUS', self.cmd_TOOLCHANGE_STATUS,
             desc=self.cmd_TOOLCHANGE_STATUS_help)
@@ -467,6 +604,7 @@ class FFToolchange:
         # was not visible to the refresh_offsets() in __init__ -- re-derive
         # now that every object exists, or Z would stay in the relative form.
         self.refresh_offsets()
+        self._register_t_commands()
         # Insert the per-tool frame under gcode_move at connect, not config
         # time, so everything registering a transform in its own __init__
         # (bed_mesh, skew_correction) is already installed and ends up BELOW
@@ -585,10 +723,52 @@ class FFToolchange:
                 " FF_IMPORT_FIRMWARE_CONFIG once)"
                 " and SAVE_CONFIG." % ", ".join("T%d" % i for i in missing))
 
-    def _make_tn(self, index):
+    def _register_t_commands(self):
+        """Claim T0..T<n-1>, once, at connect.
+
+        Every name is registered ONCE and kept, and the handler resolves the
+        map when it runs. klipper-toolchanger instead re-registers T<n> on
+        each assignment, which suits a changer whose tool count is a config
+        question; here the count is fixed at four and numbers are bounded, so
+        the set of names is constant. It also fails better: an unassigned
+        number explains itself and names ASSIGN_TOOL, where a name that came
+        and went mid-session would surface as "Unknown command: T1" against a
+        file that looks perfectly correct.
+
+        Connect rather than __init__ so that every [gcode_macro T<n>] in the
+        config has already registered -- upstream's rule is to leave a command
+        we do not own alone, and only at connect is "already there" knowable.
+        """
+        for number in range(EXTRUDER_COUNT):
+            name = 'T%d' % number
+            existing = self.gcode.register_command(name, None)
+            if existing is not None:
+                self.gcode.register_command(name, existing)
+                logging.info("%s: %s is already defined -- leaving it alone;"
+                             " this module will not answer it", self.name, name)
+                continue
+            self.gcode.register_command(name, self._make_tn(number),
+                                        desc="Select the tool assigned to"
+                                             " number %d" % number)
+            self.owned_numbers.add(number)
+
+    def _make_tn(self, number):
         def handler(gcmd):
-            self._toolchange(gcmd, index)
+            self._toolchange(gcmd, self._physical(gcmd, number))
         return handler
+
+    def _physical(self, gcmd, number):
+        """A number as a file means it -> the tool that answers it."""
+        if not 0 <= number < EXTRUDER_COUNT:
+            raise gcmd.error("T must be 0..%d, got %d"
+                             % (EXTRUDER_COUNT - 1, number))
+        physical = self.tool_map.physical_of(number)
+        if physical == _ToolMap.UNSET:
+            raise gcmd.error(
+                "T%d is not assigned to any tool. %s Assign one with"
+                " ASSIGN_TOOL TOOL=T<n> N=%d, or ASSIGN_TOOL RESET=1."
+                % (number, " ".join(self.tool_map.describe()), number))
+        return physical
 
     def _run(self, script):
         self.gcode.run_script_from_command(script)
@@ -1060,10 +1240,16 @@ class FFToolchange:
 
     # ---------------- commands ----------------
 
-    cmd_TOOLCHANGE_help = "Change to tool INDEX=0..3"
+    cmd_TOOLCHANGE_help = ("Change tool. INDEX=<number> | T=<number> is the"
+                           " number a file names; TOOL=T<n> is the tool")
 
     def cmd_TOOLCHANGE(self, gcmd):
-        self._toolchange(gcmd, gcmd.get_int('INDEX'))
+        """INDEX= is the long spelling of a bare T<n>, so it takes a NUMBER
+        and goes through the map. TOOL=T<n> addresses a head directly."""
+        tool = self._physical_arg(gcmd, required=False)
+        if tool is None:
+            tool = self._physical(gcmd, gcmd.get_int('INDEX'))
+        self._toolchange(gcmd, tool)
 
     def _toolchange(self, gcmd, tool):
         if tool < 0 or tool >= EXTRUDER_COUNT:
@@ -1329,38 +1515,54 @@ class FFToolchange:
 
     # ---------------- klipper-toolchanger command aliases ----------------
 
-    def _tool_arg(self, gcmd, required=True):
-        """klipper-toolchanger accepts T=<number> or TOOL=<name>."""
-        tool = gcmd.get_int('T', None)
-        if tool is None:
-            name = gcmd.get('TOOL', None)
-            if name is not None:
-                name = name.strip()
-                if name.upper().startswith('T') and name[1:].isdigit():
-                    tool = int(name[1:])
-                else:
-                    raise gcmd.error("TOOL must be T0..T%d, got '%s'"
-                                     % (EXTRUDER_COUNT - 1, name))
-        if tool is None:
+    def _physical_arg(self, gcmd, required=True):
+        """Resolve either spelling to a PHYSICAL tool.
+
+        klipper-toolchanger's two forms mean different things, and once a
+        number can be reassigned the difference is the whole point:
+
+            TOOL=T3   the tool ITSELF, by its permanent name. What a person
+                      or a UI types, because they mean that head.
+            T=1       the NUMBER, through the map. What a file says.
+
+        Everything below _toolchange is physical, so both land here and both
+        leave as a physical index. Under an identity map they agree, which is
+        what makes this module's own callers safe to convert ahead of the
+        feature."""
+        number = gcmd.get_int('T', None)
+        name = gcmd.get('TOOL', None)
+        if number is not None and name is not None:
+            raise gcmd.error("give T=<number> or TOOL=T<n>, not both")
+        if name is not None:
+            name = name.strip()
+            bare = name[1:] if name.upper().startswith('T') else name
+            if not bare.isdigit():
+                raise gcmd.error("TOOL names a tool: T0..T%d, got '%s'"
+                                 % (EXTRUDER_COUNT - 1, name))
+            tool = int(bare)
+            if not 0 <= tool < EXTRUDER_COUNT:
+                raise gcmd.error("TOOL must be T0..T%d, got '%s'"
+                                 % (EXTRUDER_COUNT - 1, name))
+            return tool
+        if number is None:
             if required:
-                raise gcmd.error("T=<n> or TOOL=T<n> is required")
+                raise gcmd.error("TOOL=T<n> (a tool) or T=<n> (a number)"
+                                 " is required")
             return None
-        if not 0 <= tool < EXTRUDER_COUNT:
-            raise gcmd.error("T must be 0..%d" % (EXTRUDER_COUNT - 1))
-        return tool
+        return self._physical(gcmd, number)
 
     cmd_SELECT_TOOL_help = ("Select a tool (T=<n> | TOOL=T<n>); same as"
                             " T<n>. RESTORE_AXIS=<xyz> returns the toolhead")
 
     def cmd_SELECT_TOOL(self, gcmd):
-        self._toolchange(gcmd, self._tool_arg(gcmd))
+        self._toolchange(gcmd, self._physical_arg(gcmd))
 
     cmd_UNSELECT_TOOL_help = ("Dock the mounted tool; same as"
                               " TOOLCHANGE_PARK. RESTORE_AXIS=<xyz> returns"
                               " the toolhead")
 
     def cmd_UNSELECT_TOOL(self, gcmd):
-        tool = self._tool_arg(gcmd, required=False)
+        tool = self._physical_arg(gcmd, required=False)
         if tool is not None:
             mounted, _reason = self._current_tool_or_none()
             if mounted != tool:
@@ -1408,7 +1610,7 @@ class FFToolchange:
         """Upstream addresses a tool by name; we address the extruder behind
         it. Naming the tool rather than the extruder is the whole point --
         a UI knows it is heating T2, not that T2 means [extruder2]."""
-        tool = self._tool_arg(gcmd, required=False)
+        tool = self._physical_arg(gcmd, required=False)
         if tool is None:
             tool, reason = self._current_tool_or_none()
             if tool is None or tool < 0:
@@ -1435,7 +1637,7 @@ class FFToolchange:
         motion queue; ours reads switches after a wait_moves, which costs
         nothing to do inline."""
         gcmd.get_int('ASYNC', 0)
-        expect = self._tool_arg(gcmd, required=False)
+        expect = self._physical_arg(gcmd, required=False)
         self._wait_moves()
         mounted, reason = self._current_tool_or_none()
         if mounted is None:
@@ -1621,7 +1823,19 @@ class FFToolchange:
                 # Tool whose runout/clog sensors are enabled (-1 = none)
                 # and those sensors' object names.
                 'runout_armed': self.armed_tool,
-                'runout_sensors': self._armed_sensors()}
+                'runout_sensors': self._armed_sensors(),
+                # The tool map. current_tool above stays PHYSICAL -- it is the
+                # head on the carriage, which is what all fourteen of its
+                # readers mean -- so the logical answer is a separate key
+                # rather than a change of meaning nobody would notice.
+                'current_number': (self.tool_map.number_of(tool)
+                                   if tool is not None and tool >= 0 else -1),
+                'tool_map': self.tool_map.as_list(),
+                'physical_map': self.tool_map.inverse(),
+                'tool_map_identity': self.tool_map.is_identity(),
+                # Always all four, for loops that must cover every head
+                # whatever the map says (CALIBRATE_TOOL_OFFSETS).
+                'physical_tools': list(range(EXTRUDER_COUNT))}
 
 
 def load_config(config):

--- a/pkgs/klipper/payload/klipper/klippy/extras/ff_toolchange.py
+++ b/pkgs/klipper/payload/klipper/klippy/extras/ff_toolchange.py
@@ -1434,7 +1434,9 @@ class FFToolchange:
         nozzle = gcmd.get_float('NOZZLE')
         bed = gcmd.get_float('BED', 0.)
         layer = gcmd.get_float('LAYER', 0.)
-        tool = gcmd.get_int('TOOL', -1, minval=-1, maxval=EXTRUDER_COUNT - 1)
+        tool = self._physical_arg(gcmd, required=False)
+        if tool is None:
+            tool = -1
         if tool < 0:
             current, _reason = self._current_tool_or_none()
             tool = current if current is not None and current >= 0 else 0
@@ -1491,7 +1493,7 @@ class FFToolchange:
         SET_GCODE_OFFSET Z_ADJUST without MOVE=1, the frame shifts and the
         next move lands in it, which is what babystepping into a live print
         has to do."""
-        tool = gcmd.get_int('TOOL', minval=0, maxval=EXTRUDER_COUNT - 1)
+        tool = self._physical_arg(gcmd)
         adjust = gcmd.get_float('ADJUST', None)
         value = gcmd.get_float('VALUE', None)
         save = gcmd.get_int('SAVE', 0, minval=0, maxval=1)
@@ -1666,7 +1668,9 @@ class FFToolchange:
                               " (and disable the others); TOOL= overrides")
 
     def cmd_FF_RUNOUT_ARM(self, gcmd):
-        tool = gcmd.get_int('TOOL', -1)
+        tool = self._physical_arg(gcmd, required=False)
+        if tool is None:
+            tool = -1
         if tool < 0:
             tool, reason = self._current_tool_or_none()
             if tool is None or tool < 0:

--- a/qa/static/test_klipper_config.py
+++ b/qa/static/test_klipper_config.py
@@ -153,13 +153,19 @@ def _parse_params(line, cmd):
     return {k.upper(): v for k, v in (a.split("=", 1) for a in lex)}
 
 
-def _run(model, command, has_heater):
+def _run(model, command, has_heater, status=None):
     """Expand `command` until only non-macro commands remain, as klippy would.
+
+    `status` adds printer objects the macros read but that no [gcode_macro]
+    declares -- printer.ff_toolchange, printer["tool T0"] and friends. Macros
+    that branch on the tool map are unreachable without it, and the replica
+    cannot supply the real thing: klippy never reaches ready there, for want
+    of an MCU port (qa/replica/test_mcu_bringup.py).
 
     Returns (emitted commands, action_respond_info messages).
     """
     cp = _parse(model)
-    printer = {}
+    printer = dict(status or {})
     for sec in cp.sections():
         if sec.startswith("gcode_macro "):
             variables = {}
@@ -329,3 +335,183 @@ def test_the_chamber_heater_fan_matches_the_model(model):
             "would fail lookup_heater() at klippy:ready")
         assert cp.get(sec, "pin").strip() == "PD12"
         assert "heater_fan chamber_heat_fan" not in cp.sections()
+
+
+# ---------------------------------------------------------------------------
+# The tool map: the numbers a sliced file names, against the heads that
+# answer them.
+#
+# _ToolMap itself is covered in test_tool_assignment.py. What is checked here
+# is the WIRING -- that each macro consults the map in the right direction --
+# because getting a direction backwards raises nothing at all: the machine
+# heats or grabs the wrong head and the print merely comes out wrong.
+# ---------------------------------------------------------------------------
+
+def _toolchanger(physical_map=(0, 1, 2, 3), mounted=-1, docked=(0, 1, 2, 3)):
+    """printer.ff_toolchange, as a macro reads it.
+
+    physical_map is indexed by the file's NUMBER and holds the head that
+    answers it; tool_map is its inverse, indexed by head.
+    """
+    physical_map = list(physical_map)
+    tool_map = [-1] * len(physical_map)
+    for number, head in enumerate(physical_map):
+        if head >= 0:
+            tool_map[head] = number
+    return {"ff_toolchange": {
+        "physical_map": physical_map,
+        "tool_map": tool_map,
+        "physical_tools": list(range(len(physical_map))),
+        "tool_map_identity": physical_map == list(range(len(physical_map))),
+        "current_tool": mounted,
+        "docked_tools": list(docked),
+        "calibrated_tools": [0, 1, 2, 3],
+        "station_z": 3.2,
+        "print_offset_ready": True,
+        "state_ok": True,
+    }}
+
+
+REMAPPED = (0, 3, 2, 1)   # the file's T1 is head T3, and its T3 is head T1
+
+
+@pytest.mark.parametrize("model", MODELS)
+def test_m104_with_a_tool_number_goes_through_the_tool_map(model):
+    """Klipper's own M104 resolves T straight to extruder<T>, so without the
+    wrapper a remap heats the head the file names instead of the one it
+    actually selected."""
+    out, _ = _run(model, "M104 S220 T1", has_heater=False)
+    assert out == ["SET_TOOL_TEMPERATURE T=1 TARGET=220.0"]
+
+
+@pytest.mark.parametrize("model", MODELS)
+def test_m109_with_a_tool_number_asks_to_wait(model):
+    out, _ = _run(model, "M109 S220 T1", has_heater=False)
+    assert out == ["SET_TOOL_TEMPERATURE T=1 TARGET=220.0 WAIT=1"]
+
+
+@pytest.mark.parametrize("model", MODELS)
+@pytest.mark.parametrize("command", ["M104 S220", "M109 S220"])
+def test_a_temperature_with_no_tool_falls_through_to_stock(model, command):
+    """No T means the ACTIVE extruder, which is always the right answer and
+    never the map's business -- it must not become a map lookup."""
+    out, _ = _run(model, command, has_heater=False)
+    assert out == [command.replace("M104", "M104.1").replace("M109", "M109.1")]
+
+
+@pytest.mark.parametrize("model", MODELS)
+def test_a_temperature_with_no_value_turns_the_tool_off(model):
+    out, _ = _run(model, "M104 T2", has_heater=False)
+    assert out == ["SET_TOOL_TEMPERATURE T=2 TARGET=0.0"]
+
+
+@pytest.mark.parametrize("model", MODELS)
+def test_no_shipped_macro_sets_a_temperature_by_M104_T(model):
+    """THE REGRESSION THESE EXIST FOR.
+
+    Every macro in this package means a HEAD when it names a tool, and says
+    so with SET_TOOL_TEMPERATURE TOOL=T<n>. An `M104 S0 T0` put back into a
+    macro would go through the wrapper above and be read as a NUMBER, so
+    under a remap it would heat somebody else -- silently, with the print
+    merely coming out wrong. That is a property of the text we ship, so it is
+    asserted against the text rather than by expanding every macro.
+    """
+    cp = _parse(model)
+    offenders = []
+    for sec in cp.sections():
+        if not sec.startswith("gcode_macro ") or not cp.has_option(sec, "gcode"):
+            continue
+        for line in cp.get(sec, "gcode").splitlines():
+            body = line.split(";", 1)[0]
+            if re.match(r"\s*M10[49]\b", body) and re.search(r"\bT[\d{]", body):
+                offenders.append("%s: %s" % (sec, line.strip()))
+    assert not offenders, (
+        "these address a heater by M104/M109 T, which the tool map reads as "
+        "the file's number; say SET_TOOL_TEMPERATURE TOOL=T<n> instead:\n  "
+        + "\n  ".join(offenders))
+
+
+@pytest.mark.parametrize("model", MODELS)
+def test_no_shipped_macro_selects_a_tool_by_number(model):
+    """The same trap on the motion side: T= is the file's number, TOOL= is
+    the head. Our macros always mean the head."""
+    cp = _parse(model)
+    offenders = []
+    for sec in cp.sections():
+        if not sec.startswith("gcode_macro ") or not cp.has_option(sec, "gcode"):
+            continue
+        for line in cp.get(sec, "gcode").splitlines():
+            body = line.split(";", 1)[0]
+            if re.search(r"\bSELECT_TOOL\s+T=", body):
+                offenders.append("%s: %s" % (sec, line.strip()))
+    assert not offenders, (
+        "SELECT_TOOL T= takes the file's number; use TOOL=T<n> for a head:\n  "
+        + "\n  ".join(offenders))
+
+
+@pytest.mark.parametrize("model", MODELS)
+def test_preflight_gates_the_head_the_number_points_at(model):
+    """The gate compares against docked_tools/calibrated_tools, which are
+    heads, while TOOLS= arrives as the file's numbers. Here the file's T1 is
+    head T3, which IS docked -- so this passes even though head T1 is absent.
+    """
+    _run(model, "_FF_PREFLIGHT TOOL=1 TOOLS=1", has_heater=False,
+         status=_toolchanger(REMAPPED, docked=(0, 2, 3)))
+
+
+@pytest.mark.parametrize("model", MODELS)
+def test_preflight_refuses_when_the_mapped_head_is_missing(model):
+    with pytest.raises(AssertionError, match="not installed"):
+        _run(model, "_FF_PREFLIGHT TOOL=1 TOOLS=1", has_heater=False,
+             status=_toolchanger(REMAPPED, docked=(0, 2)))
+
+
+@pytest.mark.parametrize("model", MODELS)
+def test_preflight_refuses_a_number_no_tool_answers_to(model):
+    """A displaced number is refused at the gate -- before any heating,
+    homing or grab -- not mid-file as an unknown T<n>."""
+    with pytest.raises(AssertionError, match="not assigned to any tool"):
+        _run(model, "_FF_PREFLIGHT TOOL=3 TOOLS=3", has_heater=False,
+             status=_toolchanger((0, 3, 2, -1)))
+
+
+@pytest.mark.parametrize("model", MODELS)
+def test_preflight_announces_a_non_identity_map(model):
+    """A map nobody remembers setting is a wrong print with no visible
+    cause, so it is said on every job."""
+    _, info = _run(model, "_FF_PREFLIGHT TOOL=1 TOOLS=1", has_heater=False,
+                   status=_toolchanger(REMAPPED))
+    assert any("the file's T1 is tool T3" in m for m in info), info
+
+
+@pytest.mark.parametrize("model", MODELS)
+def test_preflight_is_silent_when_the_map_is_identity(model):
+    _, info = _run(model, "_FF_PREFLIGHT TOOL=1 TOOLS=1", has_heater=False,
+                   status=_toolchanger())
+    assert not any("TOOL MAP" in m for m in info), info
+
+
+@pytest.mark.parametrize("model", MODELS)
+def test_start_print_grabs_the_head_not_the_number(model):
+    out, _ = _run(model,
+                  "START_PRINT TOOL=1 NOZZLE=220 BED=0 CLEAN=0 LEVEL=0",
+                  has_heater=False, status=_toolchanger(REMAPPED))
+    assert "SELECT_TOOL TOOL=T3" in out
+    assert "SET_TOOL_TEMPERATURE TOOL=T3 TARGET=220.0" in out
+    assert not any(re.fullmatch(r"T\d", line) for line in out), (
+        "START_PRINT must not emit a bare Tn: it has already resolved the "
+        "map, and a bare Tn would resolve it a second time")
+    assert any("TOOLCHANGE_SET_PRINT_OFFSET" in line and "TOOL=T3" in line
+               for line in out), out
+
+
+@pytest.mark.parametrize("model", MODELS)
+def test_calibrate_tool_offsets_walks_every_head_under_a_map(model):
+    """Calibration is about nozzles, so it must cover all four heads even
+    when a displacement has left tool_numbers a number short -- otherwise a
+    tool is skipped and another tool's measurement lands in its section."""
+    out, _ = _run(model, "CALIBRATE_TOOL_OFFSETS", has_heater=False,
+                  status=_toolchanger((0, 3, 2, -1)))
+    for head in range(4):
+        assert "SELECT_TOOL TOOL=T%d" % head in out, out
+    assert out.count("TOOL_CALIBRATE_TOOL_OFFSET") == 4

--- a/qa/static/test_tool_assignment.py
+++ b/qa/static/test_tool_assignment.py
@@ -1,0 +1,183 @@
+"""The tool map: which physical tool answers each number a sliced file names.
+
+THE BUG THIS EXISTS FOR. A sliced file says `T1`; until ASSIGN_TOOL existed,
+that was always physical tool 1, and printing a file whose filaments sat in
+other heads meant re-slicing. The map makes `T1` movable -- and makes every
+number in the tree ambiguous until you know which vocabulary it is written in.
+Get the direction of a lookup backwards and nothing raises: the machine grabs
+the wrong head, or TOOL_CALIBRATE_TOOL_OFFSET measures one tool and saves the
+result into another tool's section, which is a wrong nozzle_z and ~3 mm in the
+crash direction.
+
+WHY A UNIT TEST, AND WHY IT IS THIS SHAPE. The replica cannot exercise any of
+this end to end: there is no /dev/ttyS4 to hand a board over on, so klippy
+never reaches ready -- qa/replica/test_mcu_bringup.py's header says so, and
+names the simulated-MCU lane as what would close it. `_ToolMap` was extracted
+from FFToolchange precisely so the decision logic does not have to wait for
+that lane. It takes no printer, no config and no gcode object, so it imports
+and runs on the host in milliseconds. What is NOT covered here is the wiring
+-- that the map is consulted at each call site -- which is what the macro
+expansion tests in test_klipper_config.py are for.
+"""
+import importlib.util
+
+import pytest
+
+from qa.lib.paths import ROOT
+
+EXTRUDER_COUNT = 4
+
+
+def _load_tool_map():
+    """Import ff_toolchange off the shipped payload, with no klippy present.
+
+    The module imports only contextlib and logging at module level, so it
+    loads on the host interpreter. Importing the file we SHIP is the point:
+    a copy of the class in the test would pass forever after the real one
+    changed.
+    """
+    path = (ROOT / "pkgs/klipper/payload/klipper/klippy/extras"
+            / "ff_toolchange.py")
+    spec = importlib.util.spec_from_file_location("ff_toolchange", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module._ToolMap
+
+
+pytestmark = pytest.mark.static
+_ToolMap = _load_tool_map()
+IDENTITY = list(range(EXTRUDER_COUNT))
+UNSET = -1
+
+
+def _map(baseline=None):
+    return _ToolMap(IDENTITY if baseline is None else baseline)
+
+
+def test_a_fresh_map_is_the_identity():
+    m = _map()
+    assert m.is_identity()
+    assert m.as_list() == IDENTITY
+    assert m.inverse() == IDENTITY
+    assert [m.number_of(p) for p in IDENTITY] == IDENTITY
+    assert [m.physical_of(n) for n in IDENTITY] == IDENTITY
+
+
+def test_assigning_moves_the_number_and_displaces_the_previous_holder():
+    """klipper-toolchanger's replace=True: the displaced tool is left
+    unnumbered, NOT handed the assigner's old number. Swapping silently moves
+    a second tool, which is not what the operator typed."""
+    m = _map()
+    displaced = m.assign(3, 1)
+    assert displaced == 1
+    assert m.physical_of(1) == 3
+    assert m.number_of(3) == 1
+    assert m.number_of(1) == UNSET
+    assert not m.is_identity()
+
+
+def test_a_displaced_tool_is_unreachable_by_number_but_still_a_tool():
+    m = _map()
+    m.assign(3, 1)
+    # Tool 1 is the one left unnumbered -- the NUMBER 1 is very much still
+    # assigned, to tool 3. Only the bare T<n> route into tool 1 is gone;
+    # TOOL=T1 still names it, which is what every console command, dock,
+    # sensor and status object uses.
+    assert m.number_of(1) == UNSET
+    assert m.as_list()[1] == UNSET
+    assert m.physical_of(1) == 3
+    assert 1 not in [m.physical_of(n) for n in m.numbers()]
+
+
+def test_a_swap_takes_two_assignments():
+    m = _map()
+    m.assign(3, 1)
+    m.assign(1, 3)
+    assert m.physical_of(1) == 3
+    assert m.physical_of(3) == 1
+    assert m.physical_of(0) == 0
+    assert m.numbers() == IDENTITY
+    assert not m.is_identity()
+
+
+def test_reassigning_a_tool_its_own_number_changes_nothing():
+    m = _map()
+    assert m.assign(2, 2) == UNSET
+    assert m.is_identity()
+
+
+def test_an_unassigned_number_resolves_to_nothing():
+    m = _map()
+    m.assign(3, 1)
+    # 3 was vacated by the displacement; nothing answers to it.
+    assert m.physical_of(3) == UNSET
+    assert m.inverse() == [0, 3, 2, UNSET]
+
+
+def test_a_negative_or_absent_number_is_not_a_lookup():
+    """physical_of() must never treat the -1 sentinel as a number to find --
+    list.index(-1) would happily return the first unnumbered tool."""
+    m = _map()
+    m.assign(3, 1)
+    assert m.physical_of(UNSET) == UNSET
+    assert m.physical_of(None) == UNSET
+
+
+def test_reset_restores_the_configured_baseline_not_bare_identity():
+    m = _map([1, 0, 2, 3])
+    m.assign(3, 1)
+    m.reset()
+    assert m.as_list() == [1, 0, 2, 3]
+
+
+def test_identity_is_measured_against_true_identity():
+    """A machine that configures a permanent remap earns the same standing
+    notice as one that types ASSIGN_TOOL -- otherwise the map lies quietly."""
+    m = _map([1, 0, 2, 3])
+    assert not m.is_identity()
+
+
+def test_tool_numbers_are_sorted_and_tool_names_stay_parallel():
+    """klipper-toolchanger's contract, and what a tool-changer-aware UI
+    reads: tool_names[i] is the tool answering tool_numbers[i]."""
+    m = _map()
+    m.assign(3, 1)
+    # 3 dropped out (nothing answers to it now) and 1 moved to tool T3.
+    assert m.numbers() == [0, 1, 2]
+    assert m.names() == ['T0', 'T3', 'T2']
+    m.assign(1, 3)
+    assert m.numbers() == [0, 1, 2, 3]
+    assert m.names() == ['T0', 'T3', 'T2', 'T1']
+
+
+def test_the_inverse_is_dense_and_marks_gaps():
+    m = _map()
+    m.assign(0, 2)
+    assert len(m.inverse()) == EXTRUDER_COUNT
+    assert m.inverse()[2] == 0
+    assert m.inverse()[0] == UNSET
+
+
+def test_describe_is_one_quiet_line_when_the_map_is_identity():
+    assert _map().describe() == [
+        "tool map: identity (the file's T<n> is tool T<n>)"]
+
+
+def test_describe_names_every_number_and_flags_the_assigned_ones():
+    m = _map()
+    m.assign(3, 1)
+    text = "\n".join(m.describe())
+    assert "NOT IDENTITY" in text
+    assert "file T1  ->  tool T3" in text
+    assert "<- assigned" in text
+    # The displaced tool must say how it can still be reached, and the map
+    # must say it does not survive a restart.
+    assert "tool T1 has no number" in text
+    assert "TOOL=T1" in text
+    assert "RESET=1" in text
+
+
+def test_describe_flags_a_number_nothing_answers_to():
+    m = _map()
+    m.assign(3, 1)
+    assert any("file T3  ->  NOTHING" in line for line in m.describe())

--- a/qa/static/test_tool_assignment.py
+++ b/qa/static/test_tool_assignment.py
@@ -28,7 +28,7 @@ from qa.lib.paths import ROOT
 EXTRUDER_COUNT = 4
 
 
-def _load_tool_map():
+def _load_module():
     """Import ff_toolchange off the shipped payload, with no klippy present.
 
     The module imports only contextlib and logging at module level, so it
@@ -41,11 +41,12 @@ def _load_tool_map():
     spec = importlib.util.spec_from_file_location("ff_toolchange", path)
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
-    return module._ToolMap
+    return module
 
 
 pytestmark = pytest.mark.static
-_ToolMap = _load_tool_map()
+_ff = _load_module()
+_ToolMap = _ff._ToolMap
 IDENTITY = list(range(EXTRUDER_COUNT))
 UNSET = -1
 
@@ -181,3 +182,159 @@ def test_describe_flags_a_number_nothing_answers_to():
     m = _map()
     m.assign(3, 1)
     assert any("file T3  ->  NOTHING" in line for line in m.describe())
+
+
+# ---------------------------------------------------------------------------
+# ASSIGN_TOOL itself. The command is exercised against the shipped method,
+# with the handful of klippy objects it touches stubbed -- the guards are the
+# safety-relevant half and the replica cannot reach them.
+# ---------------------------------------------------------------------------
+
+class _CommandError(Exception):
+    pass
+
+
+class _Gcmd:
+    """Just enough of Klipper's GCodeCommand for these paths."""
+
+    _MISSING = object()
+
+    def __init__(self, **params):
+        self.params = {k: str(v) for k, v in params.items()}
+        self.responses = []
+
+    def get(self, name, default=_MISSING):
+        if name in self.params:
+            return self.params[name]
+        if default is self._MISSING:
+            raise _CommandError("missing %s" % name)
+        return default
+
+    def get_int(self, name, default=_MISSING, minval=None, maxval=None):
+        if name not in self.params:
+            if default is self._MISSING:
+                raise _CommandError("missing %s" % name)
+            return default
+        value = int(self.params[name])
+        if minval is not None and value < minval:
+            raise _CommandError("%s below %s" % (name, minval))
+        if maxval is not None and value > maxval:
+            raise _CommandError("%s above %s" % (name, maxval))
+        return value
+
+    def respond_info(self, message):
+        self.responses.append(message)
+
+    def error(self, message):
+        return _CommandError(message)
+
+
+class _Status:
+    def __init__(self, status):
+        self._status = status
+
+    def get_status(self, _eventtime):
+        return self._status
+
+
+class _Printer:
+    def __init__(self, objects):
+        self._objects = objects
+
+    def lookup_object(self, name, default=None):
+        return self._objects.get(name, default)
+
+
+class _Reactor:
+    def monotonic(self):
+        return 0.0
+
+
+def _changer(baseline=None, changing=False, printing=False, paused=False):
+    """A FFToolchange with only what cmd_ASSIGN_TOOL touches."""
+    changer = _ff.FFToolchange.__new__(_ff.FFToolchange)
+    changer.tool_map = _map(baseline)
+    changer.changing = changing
+    changer.reactor = _Reactor()
+    changer.printer = _Printer({
+        'print_stats': _Status({'state': 'printing' if printing else 'ready'}),
+        'pause_resume': _Status({'is_paused': paused}),
+    })
+    return changer
+
+
+def test_assign_tool_points_a_number_at_a_tool():
+    changer, gcmd = _changer(), _Gcmd(TOOL='T3', N=1)
+    changer.cmd_ASSIGN_TOOL(gcmd)
+    assert changer.tool_map.physical_of(1) == 3
+    assert "T3 now answers to 1" in gcmd.responses[0]
+
+
+def test_assign_tool_says_who_it_displaced_and_how_to_reach_them():
+    """The displaced tool is the surprise, so it must be in the response
+    along with the way back."""
+    changer, gcmd = _changer(), _Gcmd(TOOL='T3', N=1)
+    changer.cmd_ASSIGN_TOOL(gcmd)
+    said = gcmd.responses[0]
+    assert "T1 has no number" in said
+    assert "RESET=1" in said
+
+
+def test_assign_tool_accepts_a_bare_number_as_the_tool():
+    changer, gcmd = _changer(), _Gcmd(TOOL='3', N=1)
+    changer.cmd_ASSIGN_TOOL(gcmd)
+    assert changer.tool_map.physical_of(1) == 3
+
+
+def test_assign_tool_reports_a_no_op_rather_than_displacing_anyone():
+    changer, gcmd = _changer(), _Gcmd(TOOL='T2', N=2)
+    changer.cmd_ASSIGN_TOOL(gcmd)
+    assert changer.tool_map.is_identity()
+    assert "already answers" in gcmd.responses[0]
+
+
+def test_reset_restores_the_map():
+    changer = _changer()
+    changer.cmd_ASSIGN_TOOL(_Gcmd(TOOL='T3', N=1))
+    gcmd = _Gcmd(RESET=1)
+    changer.cmd_ASSIGN_TOOL(gcmd)
+    assert changer.tool_map.is_identity()
+    assert "reset" in gcmd.responses[0]
+
+
+def test_a_number_outside_the_machines_range_is_refused():
+    """Bounded because a file for this machine only ever emits T0..T3, and
+    the bound is what keeps every status list dense."""
+    changer = _changer()
+    with pytest.raises(_CommandError):
+        changer.cmd_ASSIGN_TOOL(_Gcmd(TOOL='T3', N=EXTRUDER_COUNT))
+
+
+def test_remapping_during_a_toolchange_is_refused():
+    changer = _changer(changing=True)
+    with pytest.raises(_CommandError, match="toolchange is running"):
+        changer.cmd_ASSIGN_TOOL(_Gcmd(TOOL='T3', N=1))
+
+
+def test_remapping_mid_print_is_refused():
+    """The next T<n> would go to a different nozzle, with different offsets,
+    in the middle of an object."""
+    changer = _changer(printing=True)
+    with pytest.raises(_CommandError, match="print is running"):
+        changer.cmd_ASSIGN_TOOL(_Gcmd(TOOL='T3', N=1))
+
+
+def test_remapping_while_paused_is_allowed():
+    """Paused is exactly when somebody swaps a spool and wants the rest of
+    the file pointed at another tool."""
+    changer = _changer(printing=True, paused=True)
+    changer.cmd_ASSIGN_TOOL(_Gcmd(TOOL='T3', N=1))
+    assert changer.tool_map.physical_of(1) == 3
+
+
+def test_reset_works_even_mid_print():
+    """RESET is the way out of a bad map, so it must not be gated behind the
+    state that makes a bad map dangerous."""
+    changer = _changer(printing=True)
+    changer.cmd_ASSIGN_TOOL(_Gcmd(RESET=1))
+    assert changer.tool_map.is_identity()


### PR DESCRIPTION
Adds klipper-toolchanger's `ASSIGN_TOOL`, so a file sliced for the wrong heads
prints without being sliced again.

```
ASSIGN_TOOL TOOL=T3 N=1     # the file's T1 now means tool T3
ASSIGN_TOOL RESET=1         # undo
```

## Why

A sliced file's `T1` was always physical tool 1. If a file expects PETG in T1
and the PETG is in T3, the only way out was to re-slice — and Reforge's slicer
contract is "leave the profile stock, change-filament G-code empty"
(`docs/printing.md`), so the numbering is fixed at slice time and the machine
is the only place left to remap.

## Two vocabularies

Once a number can move, "tool" means two things, and the difference matters
everywhere:

- a **tool** is the hardware — its dock, offsets, `[ff_tool 1]` section,
  `tool T1` status object. Never moves. Written `T1`.
- a **tool number** is what a file calls it. Assignable. Written `1`.

| Spelling | Means | Used by |
|---|---|---|
| `TOOL=T3` | the tool | you, a UI, every macro in this package |
| `T=1`, bare `T1`, `M104 … T1` | the number | the sliced file |

Everything below `_toolchange` stays strictly physical — docks, offsets, grab
sensors, the `ERR_*_BASE + tool` arithmetic. `_physical_arg` is the one place
the two meet.

## Temperatures follow the map too

A multi-tool file keeps idle tools warm, so nearly every temperature command
carries an explicit tool:

```gcode
M104 S180 T0        ; the tool it is about to put down
M104 S220 T1        ; the tool it is about to pick up
T1
M109 S220 T1
```

Klipper's own `M104` resolves `T` straight to `extruder<T>` and never consults
the toolchanger, so remapping `Tn` alone would grab the right nozzle and heat
the wrong one. `ff-toolchange.cfg` wraps `M104`/`M109` and routes a `T` through
the map — the same split klipper-toolchanger uses, where the extra owns tool
identity and the macros own rewriting standard G-code. With no `T` both fall
through to stock Klipper and address the active extruder.

That wrapper is also why ~10 existing call sites had to change first: the
moment `M104 T` means "number", every in-tree `M104 S0 T2` is a landmine. They
now say `SET_TOOL_TEMPERATURE TOOL=T<n>` / `SELECT_TOOL TOOL=T<n>`, which is a
no-op under the identity map. The worst of them was
`ff_tool_offset.py`'s re-grab: a bare `T%d` built from a *physical* index,
which under a remap would have measured one head and saved the result into
another tool's section — a wrong `nozzle_z`, ~3 mm in the crash direction.

## Commits

Each leaves the tree shippable; the wrapper is deliberately the last hunk of
the second commit.

| | |
|---|---|
| `3396025` | the tool map, identity-only — no behaviour change |
| `0d73319` | every call site says which vocabulary it means, then the `M104`/`M109` wrappers |
| `fda2d87` | `ASSIGN_TOOL` itself, plus the map in `TOOLCHANGE_STATUS` |
| `0c9cf62` | docs and changelog |

## Behaviour changes that are not additive

- `toolchanger.tool_number`, `tool_numbers`, `tool_names` and
  `tool T<n>.tool_number` now report the assignable **number** rather than the
  tool — klipper-toolchanger's meaning, and what HelixScreen subscribes to.
  Identical until `ASSIGN_TOOL` is used. Each tool's permanent index remains as
  `tool T<n>.physical_number`; `ff_toolchange.current_tool` is unchanged and
  still physical (fourteen readers mean "the head on the carriage").
- `SELECT_TOOL T=<n>` and `TOOLCHANGE INDEX=<n>` now take a number.

Verified against a stub changer, `ASSIGN_TOOL TOOL=T3 N=1` gives
`toolchanger.tool = "T3"`, `tool_number = 1`,
`tool_numbers/tool_names = [0,1,2] / ['T0','T3','T2']`.

## Deliberate differences from upstream

- Numbers bounded to `0..3`. Upstream allows any, because it also serves MMUs
  with a variable tool count; here the bound keeps every status list dense and
  keeps `ff_print.py`'s `^T([0-3])` file regex complete.
- `T0..T3` stay registered for the session and resolve the map when they run,
  rather than being re-registered per assignment. The name set is fixed at
  four, and an unassigned number that explains itself beats `Unknown command:
  T1` against a file that looks correct.
- `ASSIGN_TOOL` is flat, not a mux command — the `tool T<n>` objects here are
  read-only views with no command surface. Wire-identical either way.
- `RESET=1` is ours, and needed: the map is runtime-only, so a restart would
  otherwise be the only way back.
- Two guards upstream lacks: refused mid-toolchange, and mid-print unpaused
  (the next `T<n>` would go to a different nozzle mid-object). Paused is
  allowed — that is when someone swaps a spool. `RESET=1` is always allowed.

## Lifetime

Runtime only, never written by `SAVE_CONFIG` — the map answers "where is the
filament today", which is not a property of the machine. `TOOLCHANGE_STATUS`
prints it every time and `_FF_PREFLIGHT` repeats it into every job log, so a
remap set an hour ago cannot quietly ruin a print. `[ff_tool <n>] tool_number`
sets a permanent baseline that `RESET=1` returns to.

## Tests

The toolchanger had **no** coverage at all before this. Static lane goes 63 →
101 passing; `test_klipper_config.py` 17 → 45, plus a new 24-test
`test_tool_assignment.py`.

`_ToolMap` takes no printer, config or gcode object on purpose: the replica has
no MCU ports and never reaches klippy ready
(`qa/replica/test_mcu_bringup.py`), so logic that needed a live printer would
ship untested. The wiring is covered by expanding the real shipped macros —
`M104 S220 T1` → `SET_TOOL_TEMPERATURE T=1 TARGET=220.0`, bare `M104 S220` →
`M104.1 S220`, `START_PRINT TOOL=1` under a remap emitting `SELECT_TOOL
TOOL=T3` and no bare `Tn`, preflight refusing an unassigned number and
announcing the map, `CALIBRATE_TOOL_OFFSETS` still walking all four heads. Two
text assertions keep `M104 … T` and `SELECT_TOOL T=` out of shipped macros for
good.

## Still needs a machine

Nothing here has run on hardware, and the replica cannot stand in for it.
Specifically unproven: that `rename_existing: M104.1` survives on a real
printer — FlashForge's `printer.macro.cfg` defines `M106`/`M107` but neither
`M104` nor `M109`, and nothing in the tree uses `rename_existing`, so the name
looks free, but that is inference from the shipped text — and every actual
motion.

Suggested check: `TOOLCHANGE_STATUS`, then `ASSIGN_TOOL TOOL=T3 N=1`, then
`T1`, and confirm T3 is what gets grabbed *and* heated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HNAW5eNbQm4uqGgE6qf9yj
