### PR TITLE
Put FlashForge's klipperDaemon back on a printer that lost it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,13 @@ Release preparation and documentation sweep.
   fatal. Calibration and config edits made under Reforge stay in Reforge's
   directory and come back with it; a stock flash returns the machine to the
   `printer.cfg` it had before.
+- A printer that took an earlier release has FlashForge's `klipperDaemon` put
+  back for it. That file is the one thing a stock flash cannot restore — their
+  package carries no copy — so a machine whose copy was replaced could not be
+  returned to stock at all. `anvil-core` now ships FlashForge's own and
+  restores it on every install and every `apk upgrade`, so one update is
+  enough; owners who have already rolled back are served by the package at
+  [Klipper4FlashForge/stock-recovery](https://github.com/Klipper4FlashForge/stock-recovery).
 - Going back to stock works again. The mod no longer replaces
   `/usr/prog/klipper/klipperDaemon` with a shim of its own. That link was the
   one thing a stock FlashForge flash could not undo — their package carries no

--- a/docs/support.md
+++ b/docs/support.md
@@ -23,10 +23,12 @@ waits in `/usr/data/anvil-data/config` for the next time you flash Reforge.
 If your printer went back to stock and came up with a normal-looking screen
 but no Klipper — it will not home, heat or print — it took a Reforge release
 that replaced one of the printer's start-up scripts, and the stock package has
-no copy of that one to put back. Releases after this fix leave it alone; a
-printer already in that state is repaired by the package at
-[Klipper4FlashForge/stock-recovery](https://github.com/Klipper4FlashForge/stock-recovery/releases),
-flashed after the stock one.
+no copy of that one to put back. Flash the package at
+[Klipper4FlashForge/stock-recovery](https://github.com/Klipper4FlashForge/stock-recovery/releases)
+after the stock one and it starts again.
+
+Updating Reforge first avoids that trip entirely: an update puts the file back
+for you, and the printer is then free to go to stock whenever you want.
 
 ---
 

--- a/pkgs/anvil-core/payload/bin/anvil-link-prog.sh
+++ b/pkgs/anvil-core/payload/bin/anvil-link-prog.sh
@@ -97,24 +97,57 @@ link_one() {
 link_one prog/firmwareExe   /usr/prog/PROGRAM/software/firmwareExe
 link_one prog/start.sh      /usr/prog/klipper/start.sh
 
-# KLIPPERDAEMON IS FLASHFORGE'S AND IS LEFT ALONE, which is what keeps a stock
-# flash a no-op. Their package restores the two paths above -- run.sh copies
-# its own firmwareExe and start.sh over them, and busybox `cp -f` unlinks a
-# symlink rather than writing through it -- but it carries no klipperDaemon at
-# all: not in the software component, not in its md5sum.list, no line in
-# run.sh. Anything the mod puts at that path is therefore permanent, and
-# stock's start.sh, whose last line is
+# KLIPPERDAEMON IS FLASHFORGE'S, AND IS PUT BACK WHEN IT IS NOT THERE.
+#
+# Their package restores the two paths above -- run.sh copies its own
+# firmwareExe and start.sh over them, and busybox `cp -f` unlinks a symlink
+# rather than writing through it -- but it carries no klipperDaemon at all:
+# not in the software component, not in its md5sum.list, no line in run.sh.
+# Whatever sits at that path therefore survives every stock flash, and stock's
+# start.sh calls it on each boot:
 #
 #     /usr/prog/klipper/klipperDaemon start
 #
-# runs whatever it finds there for the life of the machine.
+# So the mod must not own that file, and a machine where it does cannot be
+# returned to stock: the copy FlashForge shipped is gone and only this package
+# still has one. $MODDIR/prog/stock-klipperDaemon is that copy, restored here
+# on every install and every `apk upgrade`, which is what closes the window
+# for a printer that took an earlier release.
 #
-# Nothing here needs it. start.sh above is ours and asks s6-rc; FlashForge's
-# firmwareExe execs /usr/prog/klipper/start.sh and names no other script;
-# Moonraker runs with `provider: none`, so a restart from Mainsail goes over
-# the API. The one caller left is a person at an ssh prompt, who gets
+# Nothing here calls it: start.sh above is ours and asks s6-rc, FlashForge's
+# firmwareExe execs /usr/prog/klipper/start.sh and names no other script, and
+# Moonraker runs with `provider: none`. A person at an ssh prompt gets
 # FlashForge's script and an unsupervised klippy beside the supervised one --
 # `s6-rc -u change klipper` and `s6-svc` are what to use instead.
+restore_stock_daemon() {
+    dst=/usr/prog/klipper/klipperDaemon
+    src=$MODDIR/prog/stock-klipperDaemon
+
+    # A real file is FlashForge's own, whatever version this machine has, and
+    # is left exactly as it is. Only a link into $MODDIR is this script's.
+    [ -L "$dst" ] || return 0
+    case "$(readlink "$dst")" in
+        "$MODDIR"/*) ;;
+        *) return 0 ;;
+    esac
+    [ -f "$src" ] || {
+        echo "link-prog: !! no $src -- $dst stays a link into \$MODDIR" >&2
+        return 0
+    }
+
+    # Through a temp name, and `rm` before the rename: this is the file the
+    # next boot's start.sh executes, and copying onto the link would write
+    # through it into $MODDIR instead.
+    rm -f "$dst.anvil-new"
+    if cp "$src" "$dst.anvil-new" && chmod 755 "$dst.anvil-new" &&
+       rm -f "$dst" && mv -f "$dst.anvil-new" "$dst"; then
+        echo "link-prog: $dst restored to FlashForge's own"
+    else
+        rm -f "$dst.anvil-new"
+        echo "link-prog: !! could not restore $dst" >&2
+    fi
+}
+restore_stock_daemon
 
 # ---- the live config directory ---------------------------------------------
 #

--- a/pkgs/anvil-core/payload/prog/stock-klipperDaemon
+++ b/pkgs/anvil-core/payload/prog/stock-klipperDaemon
@@ -1,0 +1,44 @@
+#!/bin/sh
+#
+# Start klipepr 
+#
+
+PYTHON=/usr/prog/Python-3.8.2/bin/python3
+KLIPPER=/usr/prog/klipper/klippy/klippy.py
+#KLIPPER_CONF=/usr/prog/klipper/runConfig/printer.cfg
+KLIPPER_CONF=/usr/data/config/printer.cfg
+KLIPPER_LOG=/usr/data/logs/printer.log
+PID_FILE=/run/klipper.pid
+KLIPPER_UDS=/tmp/uds
+KLIPPER_NICENESS=-20
+
+start() {
+    mkdir -p $(dirname $KLIPPER_LOG) # make sure the log directory exists
+    start-stop-daemon -S -b -m -p $PID_FILE -N $KLIPPER_NICENESS --exec $PYTHON -- $KLIPPER $KLIPPER_CONF -l $KLIPPER_LOG -a $KLIPPER_UDS
+}
+
+stop() {
+    start-stop-daemon -K -p $PID_FILE
+}
+restart() {
+    stop
+    sleep 2
+    start
+}
+
+case "$1" in
+  start)
+        start
+        ;;
+  stop)
+        stop
+        ;;
+  restart|reload)
+        restart
+        ;;
+  *)
+        echo "Usage: $0 {start|stop|restart}"
+        exit 1
+esac
+
+exit $?

--- a/qa/replica/test_install.py
+++ b/qa/replica/test_install.py
@@ -62,6 +62,10 @@ FE = "/usr/prog/PROGRAM/software/firmwareExe"
 # The other two stock paths anvil-link-prog.sh owns.
 START = "/usr/prog/klipper/start.sh"
 DAEMON = "/usr/prog/klipper/klipperDaemon"
+# FlashForge's own, off a factory /usr/prog. anvil-core ships this copy at
+# $MODDIR/prog/stock-klipperDaemon and restores it; a machine holding
+# anything else at that path is running a script no printer shipped with.
+STOCK_DAEMON_MD5 = "773741f6a2df3231cd52a3f441014037"
 APP = "/usr/prog/app_startup.sh"
 SOURCE = MODDIR + "/etc/s6-rc/source"
 DB = MODDIR + "/etc/s6-rc/compiled/current"
@@ -229,6 +233,38 @@ def test_klipperdaemon_is_still_flashforges_own(box):
     assert "start-stop-daemon" in daemon.text, (
         "%s is not FlashForge's own script -- it has no start-stop-daemon "
         "line: %r" % (DAEMON, daemon.text[:400]))
+
+
+def test_a_link_left_at_that_path_is_replaced_with_flashforges_own(box):
+    """An upgrade puts FlashForge's file back, so the machine can go to stock.
+
+    A printer that took a release which owned that path carries a symlink into
+    $MODDIR, and nothing in a stock package can undo it -- their package has no
+    klipperDaemon to copy over it, and the copy this machine shipped with is
+    gone. $MODDIR/prog/stock-klipperDaemon is the only copy left, and
+    anvil-link-prog.sh restores it on every install and every `apk upgrade`.
+
+    The link is planted here rather than waited for, because the machine this
+    runs on installed a release that never made one. What is under test is the
+    script in the payload, run the way an upgrade runs it.
+    """
+    link = "%s/prog/klipperDaemon" % MODDIR          # ships nowhere; dangles
+    planted = box.sh("rm -f %s && ln -s %s %s && readlink %s"
+                     % (DAEMON, link, DAEMON, DAEMON))
+    assert planted.ok, "could not plant the link: %s" % planted.text
+
+    run = box.sh("sh %s/bin/anvil-link-prog.sh" % MODDIR, timeout=300)
+    assert run.ok, "anvil-link-prog.sh failed: %s" % run.text
+
+    kind = box.sh("if [ -L %s ]; then echo link; elif [ -f %s ]; then echo file; "
+                  "else echo missing; fi" % (DAEMON, DAEMON)).out.strip()
+    assert kind == "file", (
+        "%s is %s after the upgrade, so this printer still cannot be returned "
+        "to stock. What the script said:\n%s" % (DAEMON, kind, run.text))
+    got = box.sh("md5sum %s" % DAEMON).out.split()[0]
+    assert got == STOCK_DAEMON_MD5, (
+        "%s was replaced with something that is not FlashForge's script: md5 "
+        "%s, expected %s" % (DAEMON, got, STOCK_DAEMON_MD5))
 
 
 def test_every_installed_script_parses_under_the_printers_busybox(box):

--- a/qa/static/test_shell_syntax.py
+++ b/qa/static/test_shell_syntax.py
@@ -52,6 +52,13 @@ pytestmark = pytest.mark.static
 # and says so only in s6's own log.
 SYNTAX_GLOBS = ("bin/*.sh", "pkgs/*/payload/*.sh",
                 "pkgs/*/payload/prog/*.sh", "pkgs/*/payload/prog/firmwareExe",
+                # FlashForge's own klipperDaemon, restored onto printers byte
+                # for byte. It is in the parse list and NOT in the ash list
+                # below: shellcheck reports SC2046 on their `mkdir -p $(dirname
+                # $KLIPPER_LOG)`, and the one thing this file must never get is
+                # an edit -- a printer that runs a lint-fixed copy is running
+                # something no FlashForge machine ever has.
+                "pkgs/*/payload/prog/stock-klipperDaemon",
                 "pkgs/*/payload/etc/s6-rc/" + "source/*/run",
                 "installer/*.sh",
                 "tools/replica/printer/*.sh",


### PR DESCRIPTION
Closes the one rollback path that #19 left open: a printer that took an earlier release **and then updated**.

## The gap

| Who | Rolling back to stock |
|---|---|
| Installed an old release, already rolled back | broken — [stock-recovery](https://github.com/Klipper4FlashForge/stock-recovery/releases) repairs it |
| Installed an old release, **then updated** | **broken, silently** — this PR |
| Installs the current release fresh | clean since #19 |

The middle row was verified on a machine, not reasoned about. The old release's symlink survives the update, and because #19 stopped shipping what it pointed at, it now dangles:

```
/usr/prog/klipper/klipperDaemon -> /usr/data/anvil/prog/klipperDaemon
resolves? NO -- dangling
$ sh klipperDaemon start
/bin/sh: can't open '/usr/prog/klipper/klipperDaemon': No such file or directory  rc=2
no pid file -- no klippy
```

Under the mod nothing calls that file, so nothing looks wrong. The bill arrives when the owner flashes stock: stock's `start.sh` ends in `klipperDaemon start`, and they get a working screen with no Klipper. Both update paths behave identically — an `apk upgrade` and a USB flash each run `anvil-link-prog.sh`, which is what I ran to produce the output above.

## The fix

`anvil-core` carries FlashForge's own `klipperDaemon` at `$MODDIR/prog/stock-klipperDaemon` — 845 bytes — and `anvil-link-prog.sh` copies it back whenever it finds a link into `$MODDIR` at that path. A real file there is FlashForge's, whatever version the machine has, and is never touched.

It runs on every install and every `apk upgrade`, so one update closes the window. Owners who have **already** rolled back cannot be reached from inside the mod at all — nothing of ours runs during a stock flash — and stay served by the recovery package.

## Why their file is shipped rather than reconstructed

The copy those printers left the factory with is gone, and no FlashForge package will put one back. This is the only copy left. It is committed byte for byte, so it is in the syntax-parse list and deliberately **out** of the shellcheck list: they write `mkdir -p $(dirname $KLIPPER_LOG)`, which is `SC2046`, and a lint fix would put a script on printers that no FlashForge machine has ever run. The replica asserts its md5 after the restore for the same reason.

## Testing

`make qa` on a package built from this branch: **466 passed, 1 skipped**, both lanes.

The new replica test plants the link an older release leaves, runs the payload's `anvil-link-prog.sh` the way an upgrade runs it, and asserts the path is a real file afterwards with md5 `773741f6…`. Alongside it, `test_klipperdaemon_is_still_flashforges_own` continues to assert the fresh-install case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)