### PR TITLE
versions.md: the HelixScreen pin, and a Klipper commit rather than a branch

### DIFF
--- a/docs/versions.md
+++ b/docs/versions.md
@@ -7,10 +7,10 @@ whatever was current when it was built.
 | Component | Pinned at |
 |---|---|
 | Stock FlashForge base | `1.9.7-1.2.9-20260810`, fetched from [ghzserg/FF](https://github.com/ghzserg/FF) at build time |
-| [Klipper](https://github.com/Klipper4FlashForge/klipper/tree/creator5) | a current fork (branch `creator5`) with the `ff_*` toolchanger extras |
+| [Klipper](https://github.com/Klipper4FlashForge/klipper/tree/creator5) | [`b722a4c8`](https://github.com/Klipper4FlashForge/klipper/commit/b722a4c8b1aedfb939a7688a9b30e7864fddd505) on branch `creator5`, with the `ff_*` toolchanger extras |
 | [Mainsail](https://github.com/mainsail-crew/mainsail) | [`v2.18.2`](https://github.com/mainsail-crew/mainsail/releases/tag/v2.18.2) |
 | [Moonraker](https://github.com/Arksine/moonraker) | [`v0.11.0`](https://github.com/Arksine/moonraker/releases/tag/v0.11.0) |
-| [HelixScreen](https://github.com/Klipper4FlashForge/helixscreen) | [`v0.99.115-creator5.1`](https://github.com/Klipper4FlashForge/helixscreen/releases/tag/v0.99.115-creator5.1) |
+| [HelixScreen](https://github.com/Klipper4FlashForge/helixscreen) | [`v0.99.115-creator5.5`](https://github.com/Klipper4FlashForge/helixscreen/releases/tag/v0.99.115-creator5.5) |
 
 How the pieces fit together on the printer — which of them is a service, what
 starts what, and what stays stock — is [How it works](how-it-works.md).


### PR DESCRIPTION
The page's own premise is that "a release is a fixed set of these versions", and two rows did not hold it up:

- **HelixScreen** said `v0.99.115-creator5.1`. `versions.env` has pinned `v0.99.115-creator5.5` since it shipped in `v20260827d`.
- **Klipper** said "a current fork (branch `creator5`)" — a branch is not a pin, and the build uses a commit. It now names `b722a4c8` and links it.

`versions.env` itself is correct and unchanged: `HELIX_FILE` has to be the release asset's own name, because the download URL is `.../releases/download/$HELIX_VERSION/$HELIX_FILE`, and the pinned sha256 already matches the `creator5.5` asset — which is why CI fetches it and passes.

Docs only; `mkdocs build --strict` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
